### PR TITLE
fix: update binary names and checksum verification in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,13 +228,13 @@ jobs:
 
           Choose the appropriate binary for your platform:
 
-          - **macOS (Intel)**: \`ten-second-tom-osx-x64\`
-          - **macOS (Apple Silicon)**: \`ten-second-tom-osx-arm64\`
-          - **Windows**: \`ten-second-tom-win-x64\`
+          - **macOS (Intel)**: \`tom\` (from ten-second-tom-osx-x64)
+          - **macOS (Apple Silicon)**: \`tom\` (from ten-second-tom-osx-arm64)
+          - **Windows**: \`tom.exe\` (from ten-second-tom-win-x64)
 
           ### ✅ Verification
 
-          SHA256 checksums are provided in \`checksum.txt\` files for each platform."
+          Use \`shasum -a 256\` or \`Get-FileHash\` to verify the downloaded binaries."
           else
             echo "📝 Generating changelog from $PREV_TAG to $VERSION"
             
@@ -249,13 +249,13 @@ jobs:
 
           Choose the appropriate binary for your platform:
 
-          - **macOS (Intel)**: \`ten-second-tom-osx-x64\`
-          - **macOS (Apple Silicon)**: \`ten-second-tom-osx-arm64\`
-          - **Windows**: \`ten-second-tom-win-x64\`
+          - **macOS (Intel)**: \`tom\` (from ten-second-tom-osx-x64)
+          - **macOS (Apple Silicon)**: \`tom\` (from ten-second-tom-osx-arm64)
+          - **Windows**: \`tom.exe\` (from ten-second-tom-win-x64)
 
           ### ✅ Verification
 
-          SHA256 checksums are provided in \`checksum.txt\` files for each platform."
+          Use \`shasum -a 256\` or \`Get-FileHash\` to verify the downloaded binaries."
           fi
           
           # Save notes to file (handle multiline)
@@ -284,25 +284,16 @@ jobs:
           # Upload macOS x64
           gh release upload "$VERSION" \
             ./artifacts/ten-second-tom-osx-x64/tom \
-            ./artifacts/ten-second-tom-osx-x64/checksum.txt \
             --clobber
-          
-          # Rename checksum for clarity
-          mv ./artifacts/ten-second-tom-osx-x64/checksum.txt ./artifacts/ten-second-tom-osx-x64/checksums-osx-x64.txt
           
           # Upload macOS ARM64
           gh release upload "$VERSION" \
             ./artifacts/ten-second-tom-osx-arm64/tom \
-            ./artifacts/ten-second-tom-osx-arm64/checksum.txt \
             --clobber
-          
-          # Rename checksum for clarity
-          mv ./artifacts/ten-second-tom-osx-arm64/checksum.txt ./artifacts/ten-second-tom-osx-arm64/checksums-osx-arm64.txt
           
           # Upload Windows x64
           gh release upload "$VERSION" \
             ./artifacts/ten-second-tom-win-x64/tom.exe \
-            ./artifacts/ten-second-tom-win-x64/checksum.txt \
             --clobber
           
           echo "✅ All artifacts uploaded"
@@ -387,11 +378,13 @@ jobs:
           echo "bottle-tag=$BOTTLE_TAG" >> $GITHUB_OUTPUT
           echo "bottle-sha=$BOTTLE_SHA" >> $GITHUB_OUTPUT
           
-          # Also get checksums for both architectures for formula
-          SHA256_X64=$(cat ./artifacts/ten-second-tom-osx-x64/checksum.txt | cut -d ' ' -f 1)
-          SHA256_ARM64=$(cat ./artifacts/ten-second-tom-osx-arm64/checksum.txt | cut -d ' ' -f 1)
+          # Calculate checksums for both architectures directly from binaries
+          SHA256_X64=$(shasum -a 256 ./artifacts/ten-second-tom-osx-x64/tom | cut -d ' ' -f 1)
+          SHA256_ARM64=$(shasum -a 256 ./artifacts/ten-second-tom-osx-arm64/tom | cut -d ' ' -f 1)
           echo "sha256-x64=$SHA256_X64" >> $GITHUB_OUTPUT
           echo "sha256-arm64=$SHA256_ARM64" >> $GITHUB_OUTPUT
+          echo "   x64 SHA256: $SHA256_X64"
+          echo "   ARM64 SHA256: $SHA256_ARM64"
       
       - name: Upload bottle to GitHub Packages
         run: |


### PR DESCRIPTION
This pull request updates the release workflow to simplify binary naming and checksum handling for all platforms. The main changes streamline artifact uploads, clarify binary names for users, and improve checksum calculation and verification instructions.

**Release artifact and workflow improvements:**

* Updated release notes to refer to the binaries as `tom` (for macOS) and `tom.exe` (for Windows), replacing the previous longer names, and clarified their origins for each platform. Also improved verification instructions by suggesting platform-specific commands instead of referencing separate checksum files. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L231-R237) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L252-R258)
* Removed the upload and renaming of separate `checksum.txt` files for each platform during artifact release, reducing unnecessary files and steps.

**Checksum calculation changes:**

* Changed checksum calculation to be performed directly on the released binaries using `shasum -a 256`, rather than reading from pre-generated `checksum.txt` files. This ensures the checksums are always accurate and up-to-date with the actual uploaded files.