### PR TITLE
Fixed LLM provider configuration detect and handling

### DIFF
--- a/src/Features/ThisWeek/Handlers/CreateWeeklyReviewHandler.cs
+++ b/src/Features/ThisWeek/Handlers/CreateWeeklyReviewHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using TenSecondTom.Features.ThisWeek.Commands;
 using TenSecondTom.Infrastructure.Auth;
+using TenSecondTom.Infrastructure.Configuration;
 using TenSecondTom.Infrastructure.Llm;
 using TenSecondTom.Infrastructure.Prompts;
 using TenSecondTom.Infrastructure.Storage;
@@ -21,6 +22,7 @@ public sealed class CreateWeeklyReviewHandler : IRequestHandler<CreateWeeklyRevi
     private readonly ILlmProviderFactory _llmFactory;
     private readonly IPromptTemplateLoader _promptLoader;
     private readonly IAuthenticationService _authService;
+    private readonly IConfigurationStorageService _configService;
     private readonly ILogger<CreateWeeklyReviewHandler> _logger;
 
     /// <summary>
@@ -30,18 +32,21 @@ public sealed class CreateWeeklyReviewHandler : IRequestHandler<CreateWeeklyRevi
     /// <param name="llmFactory">The LLM provider factory.</param>
     /// <param name="promptLoader">The prompt template loader.</param>
     /// <param name="authService">The authentication service.</param>
+    /// <param name="configService">The configuration storage service.</param>
     /// <param name="logger">The logger instance.</param>
     public CreateWeeklyReviewHandler(
         IMemoryStorageProvider storage,
         ILlmProviderFactory llmFactory,
         IPromptTemplateLoader promptLoader,
         IAuthenticationService authService,
+        IConfigurationStorageService configService,
         ILogger<CreateWeeklyReviewHandler> logger)
     {
         _storage = storage;
         _llmFactory = llmFactory;
         _promptLoader = promptLoader;
         _authService = authService;
+        _configService = configService;
         _logger = logger;
     }
 
@@ -109,16 +114,44 @@ public sealed class CreateWeeklyReviewHandler : IRequestHandler<CreateWeeklyRevi
 
         string prompt = RenderPrompt(templateResult.Value, aggregatedContent, dateRange, entriesResult.Value.Count);
 
-        // 8. Call LLM provider
-    string provider = request.LlmProviderOverride ?? LlmProviders.OpenAI;
+        // 8. Determine LLM provider (use override, or load from config, or default to OpenAI)
+        string provider;
+        if (!string.IsNullOrWhiteSpace(request.LlmProviderOverride))
+        {
+            provider = request.LlmProviderOverride;
+        }
+        else
+        {
+            // Load from configuration
+            Result<Features.Setup.Models.ConfigurationSettings> configResult = await _configService.LoadAsync(cancellationToken).ConfigureAwait(false);
+            if (configResult.IsSuccess && configResult.Value.Llm.Provider != Features.Setup.Models.LlmProvider.OpenAI)
+            {
+                // Convert enum to string
+                provider = configResult.Value.Llm.Provider.ToString();
+            }
+            else
+            {
+                // Default to OpenAI
+                provider = LlmProviders.OpenAI;
+                if (!configResult.IsSuccess)
+                {
+                    _logger.LogDebug("Could not load configuration, defaulting to OpenAI: {Error}", configResult.Error);
+                }
+            }
+        }
+
         ILlmProvider llmProvider;
         try
         {
             llmProvider = _llmFactory.CreateProvider(provider);
         }
-        catch (Exception ex)
+        catch (ArgumentException ex)
         {
             return Result<WeeklyEntry>.Failure($"Invalid LLM provider '{provider}'. Use 'OpenAI' or 'Anthropic'. Error: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Result<WeeklyEntry>.Failure($"Failed to create LLM provider '{provider}': {ex.Message}");
         }
 
         _logger.LogDebug("Calling LLM provider {Provider} for weekly review", provider);

--- a/src/Features/Today/Handlers/CreateDailyEntryHandler.cs
+++ b/src/Features/Today/Handlers/CreateDailyEntryHandler.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using TenSecondTom.Features.Today.Commands;
 using TenSecondTom.Infrastructure.Auth;
+using TenSecondTom.Infrastructure.Configuration;
 using TenSecondTom.Infrastructure.Llm;
 using TenSecondTom.Infrastructure.Prompts;
 using TenSecondTom.Infrastructure.Storage;
@@ -16,12 +17,14 @@ namespace TenSecondTom.Features.Today.Handlers;
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1515:Consider making public types internal", Justification = "Public API by design")]
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2254:Template should be a static expression", Justification = "Structured logging pattern")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification = "Simple logging calls, delegate overhead not justified")]
 public sealed class CreateDailyEntryHandler : IRequestHandler<CreateDailyEntryCommand, Result<DailyEntry>>
 {
     private readonly IMemoryStorageProvider _storage;
     private readonly ILlmProviderFactory _llmFactory;
     private readonly IPromptTemplateLoader _promptLoader;
     private readonly IAuthenticationService _authService;
+    private readonly IConfigurationStorageService _configService;
     private readonly ILogger<CreateDailyEntryHandler> _logger;
 
     /// <summary>
@@ -31,18 +34,21 @@ public sealed class CreateDailyEntryHandler : IRequestHandler<CreateDailyEntryCo
     /// <param name="llmFactory">The LLM provider factory.</param>
     /// <param name="promptLoader">The prompt template loader.</param>
     /// <param name="authService">The authentication service.</param>
+    /// <param name="configService">The configuration storage service.</param>
     /// <param name="logger">The logger instance.</param>
     public CreateDailyEntryHandler(
         IMemoryStorageProvider storage,
         ILlmProviderFactory llmFactory,
         IPromptTemplateLoader promptLoader,
         IAuthenticationService authService,
+        IConfigurationStorageService configService,
         ILogger<CreateDailyEntryHandler> logger)
     {
         _storage = storage;
         _llmFactory = llmFactory;
         _promptLoader = promptLoader;
         _authService = authService;
+        _configService = configService;
         _logger = logger;
     }
 
@@ -94,8 +100,32 @@ public sealed class CreateDailyEntryHandler : IRequestHandler<CreateDailyEntryCo
 
         string prompt = RenderPrompt(templateResult.Value, userInput);
 
-        // 6. Call LLM provider
-    string provider = request.LlmProviderOverride ?? LlmProviders.OpenAI; // Default to OpenAI if not specified
+        // 6. Determine LLM provider (use override, or load from config, or default to OpenAI)
+        string provider;
+        if (!string.IsNullOrWhiteSpace(request.LlmProviderOverride))
+        {
+            provider = request.LlmProviderOverride;
+        }
+        else
+        {
+            // Load from configuration
+            Result<Features.Setup.Models.ConfigurationSettings> configResult = await _configService.LoadAsync(cancellationToken).ConfigureAwait(false);
+            if (configResult.IsSuccess && configResult.Value.Llm.Provider != Features.Setup.Models.LlmProvider.OpenAI)
+            {
+                // Convert enum to string
+                provider = configResult.Value.Llm.Provider.ToString();
+            }
+            else
+            {
+                // Default to OpenAI
+                provider = LlmProviders.OpenAI;
+                if (!configResult.IsSuccess)
+                {
+                    _logger.LogDebug("Could not load configuration, defaulting to OpenAI: {Error}", configResult.Error);
+                }
+            }
+        }
+
         ILlmProvider llmProvider;
         try
         {
@@ -103,7 +133,11 @@ public sealed class CreateDailyEntryHandler : IRequestHandler<CreateDailyEntryCo
         }
         catch (ArgumentException ex)
         {
-            return Result<DailyEntry>.Failure($"Invalid LLM provider. Use 'OpenAI' or 'Anthropic'. Error: {ex.Message}");
+            return Result<DailyEntry>.Failure($"Invalid LLM provider '{provider}'. Use 'OpenAI' or 'Anthropic'. Error: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Result<DailyEntry>.Failure($"Failed to create LLM provider '{provider}': {ex.Message}");
         }
 
         Result<string> llmResult = await llmProvider.GenerateCompletionAsync(prompt, cancellationToken).ConfigureAwait(false);

--- a/src/Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -84,8 +84,8 @@ public static class ServiceCollectionExtensions
                 sshKeyLogger);
         });
 
-        // Register OpenAI ChatClient
-        services.AddSingleton<ChatClient>(serviceProvider =>
+        // Register OpenAI ChatClient (lazy - only instantiated when OpenAI provider is actually used)
+        services.AddTransient<ChatClient>(serviceProvider =>
         {
             var configuration = serviceProvider.GetRequiredService<IConfiguration>();
             string? apiKey = configuration["OPENAI_API_KEY"] ?? 
@@ -102,8 +102,8 @@ public static class ServiceCollectionExtensions
             return openAIClient.GetChatClient(model);
         });
 
-        // Register Anthropic AnthropicClient
-        services.AddSingleton<AnthropicClient>(serviceProvider =>
+        // Register Anthropic AnthropicClient (lazy - only instantiated when Anthropic provider is actually used)
+        services.AddTransient<AnthropicClient>(serviceProvider =>
         {
             var configuration = serviceProvider.GetRequiredService<IConfiguration>();
             string? apiKey = configuration["ANTHROPIC_API_KEY"] ?? 

--- a/src/TenSecondTom.csproj
+++ b/src/TenSecondTom.csproj
@@ -11,6 +11,8 @@
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>link</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+    <!-- Enable JSON serialization reflection for Anthropic SDK compatibility -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <!-- Suppress specific trimming warnings -->
     <NoWarn>$(NoWarn);IL2026;IL2067;IL2070;IL2075;IL2077;IL3050</NoWarn>
   </PropertyGroup>
@@ -21,6 +23,7 @@
     <TrimmerRootAssembly Include="Serilog.Sinks.File" />
     <TrimmerRootAssembly Include="Serilog.Enrichers.Environment" />
     <TrimmerRootAssembly Include="Serilog.Settings.Configuration" />
+    <TrimmerRootAssembly Include="Anthropic.SDK" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -11,7 +11,7 @@
       "MaxTokens": 2000
     },
     "Anthropic": {
-      "Model": "claude-3-sonnet-20240229",
+      "Model": "claude-sonnet-4-20250514",
       "MaxTokens": 2000
     },
     "DataRetention": {

--- a/tests/TenSecondTom.Tests/Unit/Features/ThisWeek/CreateWeeklyReviewHandlerTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Features/ThisWeek/CreateWeeklyReviewHandlerTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using TenSecondTom.Features.ThisWeek.Commands;
 using TenSecondTom.Features.ThisWeek.Handlers;
 using TenSecondTom.Infrastructure.Auth;
+using TenSecondTom.Infrastructure.Configuration;
 using TenSecondTom.Infrastructure.Llm;
 using TenSecondTom.Infrastructure.Prompts;
 using TenSecondTom.Infrastructure.Storage;
@@ -23,6 +24,7 @@ public sealed class CreateWeeklyReviewHandlerTests
     private readonly Mock<ILlmProvider> _mockLlmProvider;
     private readonly Mock<IPromptTemplateLoader> _mockPromptLoader;
     private readonly Mock<IAuthenticationService> _mockAuthService;
+    private readonly Mock<IConfigurationStorageService> _mockConfigService;
     private readonly Mock<ILogger<CreateWeeklyReviewHandler>> _mockLogger;
     private readonly CreateWeeklyReviewHandler _handler;
 
@@ -33,6 +35,7 @@ public sealed class CreateWeeklyReviewHandlerTests
         _mockLlmProvider = new Mock<ILlmProvider>();
         _mockPromptLoader = new Mock<IPromptTemplateLoader>();
         _mockAuthService = new Mock<IAuthenticationService>();
+        _mockConfigService = new Mock<IConfigurationStorageService>();
         _mockLogger = new Mock<ILogger<CreateWeeklyReviewHandler>>();
 
         // Setup default successful behaviors
@@ -79,6 +82,7 @@ Noticed pattern of afternoon productivity dips.
             _mockLlmFactory.Object,
             _mockPromptLoader.Object,
             _mockAuthService.Object,
+            _mockConfigService.Object,
             _mockLogger.Object);
     }
 

--- a/tests/TenSecondTom.Tests/Unit/Features/Today/CreateDailyEntryHandlerTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Features/Today/CreateDailyEntryHandlerTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using TenSecondTom.Features.Today.Commands;
 using TenSecondTom.Features.Today.Handlers;
 using TenSecondTom.Infrastructure.Auth;
+using TenSecondTom.Infrastructure.Configuration;
 using TenSecondTom.Infrastructure.Llm;
 using TenSecondTom.Infrastructure.Prompts;
 using TenSecondTom.Infrastructure.Storage;
@@ -24,6 +25,7 @@ public sealed class CreateDailyEntryHandlerTests
     private readonly Mock<ILlmProvider> _mockLlmProvider;
     private readonly Mock<IPromptTemplateLoader> _mockPromptLoader;
     private readonly Mock<IAuthenticationService> _mockAuthService;
+    private readonly Mock<IConfigurationStorageService> _mockConfigService;
     private readonly Mock<ILogger<CreateDailyEntryHandler>> _mockLogger;
     private readonly CreateDailyEntryHandler _handler;
 
@@ -34,6 +36,7 @@ public sealed class CreateDailyEntryHandlerTests
         _mockLlmProvider = new Mock<ILlmProvider>();
         _mockPromptLoader = new Mock<IPromptTemplateLoader>();
         _mockAuthService = new Mock<IAuthenticationService>();
+        _mockConfigService = new Mock<IConfigurationStorageService>();
         _mockLogger = new Mock<ILogger<CreateDailyEntryHandler>>();
 
         // Setup default successful behaviors
@@ -72,6 +75,7 @@ public sealed class CreateDailyEntryHandlerTests
             _mockLlmFactory.Object,
             _mockPromptLoader.Object,
             _mockAuthService.Object,
+            _mockConfigService.Object,
             _mockLogger.Object);
     }
 


### PR DESCRIPTION
- AI provider detection was not actually working, just defaulting to OpenAI. It now works correctly
- Serialization support for the anthropic sdk
- using old Claude model in config, new default is Claude sonnet 4
- updated tests

This pull request improves how the application selects and instantiates LLM (Large Language Model) providers for daily and weekly review generation, making provider selection configurable and more robust. It also updates dependency injection for LLM clients, ensures compatibility with the Anthropic SDK, and updates the default Anthropic model. Unit tests have been updated to reflect these changes.

**LLM Provider Selection and Error Handling Improvements:**

* The logic in `CreateDailyEntryHandler` and `CreateWeeklyReviewHandler` now checks for an explicit provider override, falls back to a configurable provider from persistent settings, and defaults to OpenAI if none is set. More robust error handling is added for provider instantiation failures. [[1]](diffhunk://#diff-f22b2d188f4b5b6d589e811e537617f2fdb539680a20e4b182506c1bca6303c6L97-R140) [[2]](diffhunk://#diff-c05599581343d11771f577286de9333e02c9d51a56ea80cf92e74d56dff829c0L112-R155)
* Both handlers now depend on `IConfigurationStorageService`, which is injected via constructor and used to load provider configuration. [[1]](diffhunk://#diff-f22b2d188f4b5b6d589e811e537617f2fdb539680a20e4b182506c1bca6303c6R4) [[2]](diffhunk://#diff-f22b2d188f4b5b6d589e811e537617f2fdb539680a20e4b182506c1bca6303c6R20-R27) [[3]](diffhunk://#diff-f22b2d188f4b5b6d589e811e537617f2fdb539680a20e4b182506c1bca6303c6R37-R51) [[4]](diffhunk://#diff-c05599581343d11771f577286de9333e02c9d51a56ea80cf92e74d56dff829c0R4) [[5]](diffhunk://#diff-c05599581343d11771f577286de9333e02c9d51a56ea80cf92e74d56dff829c0R25) [[6]](diffhunk://#diff-c05599581343d11771f577286de9333e02c9d51a56ea80cf92e74d56dff829c0R35-R49)

**Dependency Injection Improvements:**

* The dependency injection setup for `ChatClient` (OpenAI) and `AnthropicClient` is changed from singleton to transient, ensuring clients are only instantiated if their respective providers are used. This is more efficient and avoids unnecessary resource allocation. [[1]](diffhunk://#diff-be4f1e680f919e891c041f35fc118eb7f1659056c70a0cd8585cef3cc6d6cbcaL87-R88) [[2]](diffhunk://#diff-be4f1e680f919e891c041f35fc118eb7f1659056c70a0cd8585cef3cc6d6cbcaL105-R106)

**SDK Compatibility and Model Update:**

* The project file is updated to enable JSON serialization reflection for compatibility with the Anthropic SDK, and the SDK is added as a trimming root. [[1]](diffhunk://#diff-3bcc26d5a373b18491081feb4a6e1e7dfbbded224c7a9cb6d1fdc8cdcd5abed4R14-R15) [[2]](diffhunk://#diff-3bcc26d5a373b18491081feb4a6e1e7dfbbded224c7a9cb6d1fdc8cdcd5abed4R26)
* The default Anthropic model in `appsettings.json` is updated to `claude-sonnet-4-20250514`.

**Unit Test Updates:**

* Unit tests for daily and weekly handlers are updated to mock and inject the new configuration service dependency. [[1]](diffhunk://#diff-c391d7d3bca660f21fb6fd38e2eb57200d09224c6099920b080602db6f2074bcR7) [[2]](diffhunk://#diff-c391d7d3bca660f21fb6fd38e2eb57200d09224c6099920b080602db6f2074bcR27) [[3]](diffhunk://#diff-c391d7d3bca660f21fb6fd38e2eb57200d09224c6099920b080602db6f2074bcR38) [[4]](diffhunk://#diff-c391d7d3bca660f21fb6fd38e2eb57200d09224c6099920b080602db6f2074bcR85) [[5]](diffhunk://#diff-6b35b07270ab363137a3f962643c7497c4ea589aac495897fdc3cf394910a46bR7) [[6]](diffhunk://#diff-6b35b07270ab363137a3f962643c7497c4ea589aac495897fdc3cf394910a46bR28) [[7]](diffhunk://#diff-6b35b07270ab363137a3f962643c7497c4ea589aac495897fdc3cf394910a46bR39) [[8]](diffhunk://#diff-6b35b07270ab363137a3f962643c7497c4ea589aac495897fdc3cf394910a46bR78)