### PR TITLE
Escape entire choice string to prevent Spectre.Console markup

### DIFF
--- a/src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs
+++ b/src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs
@@ -107,11 +107,9 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         
         foreach (var model in models)
         {
-            // Escape any markup in description/display name to avoid Spectre parsing issues
-            var displayName = model.DisplayName.EscapeMarkup();
-            var costTier = model.CostTier.EscapeMarkup();
-            var description = model.Description.EscapeMarkup();
-            var choice = $"{displayName} [{costTier}] - {description}";
+            // Build the choice string and escape the entire thing to prevent Spectre.Console
+            // from interpreting square brackets as markup (e.g., [Balanced] would be treated as a style)
+            var choice = $"{model.DisplayName} [{model.CostTier}] - {model.Description}".EscapeMarkup();
             choices.Add(choice);
             choiceToModel[choice] = model;
         }


### PR DESCRIPTION
This pull request updates how model choices are displayed in the `SpectreConsoleSetupWizard` to prevent Spectre.Console from misinterpreting square brackets as markup. Instead of escaping each property individually, the entire choice string is now escaped after formatting.

Display formatting improvement:

* In `src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs`, the construction of the `choice` string for model selection now escapes the whole formatted string, ensuring that square brackets (such as those in cost tiers) are not parsed as markup by Spectre.Console.