### PR TITLE
fix: Introduce SetupWizardConstants for consistent UI display strings

### DIFF
--- a/src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs
+++ b/src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using TenSecondTom.Features.Setup.Models;
+using TenSecondTom.Shared.Constants;
 
 namespace TenSecondTom.Features.Setup.Handlers;
 
@@ -10,18 +11,12 @@ namespace TenSecondTom.Features.Setup.Handlers;
 /// </summary>
 public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
 {
-    private static readonly string[] LlmProviderChoices =
-    [
-        "OpenAI (GPT)",
-        "Anthropic (Claude)"
-    ];
-
     private static readonly string[] LogLevelChoices =
     [
-        "Debug (verbose)",
-        "Information (recommended)",
-        "Warning (quiet)",
-        "Error (silent)"
+        SetupWizardConstants.LogLevelDisplayNames.Debug,
+        SetupWizardConstants.LogLevelDisplayNames.Information,
+        SetupWizardConstants.LogLevelDisplayNames.Warning,
+        SetupWizardConstants.LogLevelDisplayNames.Error
     ];
 
     private readonly IAnsiConsole _console;
@@ -79,7 +74,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
     {
         var prompt = new SelectionPrompt<string>()
             .Title("Choose your AI provider:")
-            .AddChoices(LlmProviderChoices);
+            .AddChoices(SetupWizardConstants.ProviderDisplayNames.GetDisplayNames());
 
         if (currentProvider.HasValue)
         {
@@ -157,8 +152,13 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         string? currentApiKey,
         CancellationToken cancellationToken)
     {
-        var providerName = provider == LlmProvider.OpenAI ? "OpenAI" : "Anthropic";
-        var prompt = new TextPrompt<string>($"Enter your {providerName} API key:")
+        // Convert enum to provider name constant, then to display name
+        var providerName = provider == LlmProvider.OpenAI 
+            ? LlmProviders.OpenAI 
+            : LlmProviders.Anthropic;
+        var displayName = SetupWizardConstants.ProviderDisplayNames.GetDisplayName(providerName);
+        
+        var prompt = new TextPrompt<string>($"Enter your {displayName} API key:")
             .Secret();
 
         if (!string.IsNullOrEmpty(currentApiKey))
@@ -176,7 +176,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
     {
         var defaultDir = currentDirectory ?? 
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), 
-                ".memory", "ten-second-tom");
+                DirectoryNames.ApplicationRoot);
 
         var prompt = new TextPrompt<string>("Where should I store your memories?")
             .DefaultValue(defaultDir)
@@ -198,10 +198,10 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         
         var logLevel = selected switch
         {
-            "Debug (verbose)" => Microsoft.Extensions.Logging.LogLevel.Debug,
-            "Information (recommended)" => Microsoft.Extensions.Logging.LogLevel.Information,
-            "Warning (quiet)" => Microsoft.Extensions.Logging.LogLevel.Warning,
-            "Error (silent)" => Microsoft.Extensions.Logging.LogLevel.Error,
+            SetupWizardConstants.LogLevelDisplayNames.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+            SetupWizardConstants.LogLevelDisplayNames.Information => Microsoft.Extensions.Logging.LogLevel.Information,
+            SetupWizardConstants.LogLevelDisplayNames.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
+            SetupWizardConstants.LogLevelDisplayNames.Error => Microsoft.Extensions.Logging.LogLevel.Error,
             _ => Microsoft.Extensions.Logging.LogLevel.Information
         };
 
@@ -213,20 +213,22 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         CancellationToken cancellationToken)
     {
         _console.MarkupLine("[grey]ℹ️  Choose how long to keep your memories before automatic deletion.[/]");
-        _console.MarkupLine("[grey]   Enter 'unlimited' to keep all memories forever (recommended).[/]");
+        _console.MarkupLine($"[grey]   Enter '{SetupWizardConstants.RetentionKeywords.Unlimited}' to keep all memories forever (recommended).[/]");
         _console.WriteLine();
 
         var prompt = new TextPrompt<string>("How long should memories be kept? (enter 'unlimited' or number of days)")
-            .DefaultValue(currentDays.HasValue && currentDays.Value > 0 ? currentDays.Value.ToString() : "unlimited")
+            .DefaultValue(currentDays.HasValue && currentDays.Value > 0 
+                ? currentDays.Value.ToString() 
+                : SetupWizardConstants.RetentionKeywords.Unlimited)
             .AllowEmpty();
 
         var input = _console.Prompt(prompt);
         
         // Parse input: "unlimited", "forever", "0" -> -1, otherwise parse as number
         if (string.IsNullOrWhiteSpace(input) || 
-            input.Equals("unlimited", StringComparison.OrdinalIgnoreCase) ||
-            input.Equals("forever", StringComparison.OrdinalIgnoreCase) ||
-            input == "0")
+            input.Equals(SetupWizardConstants.RetentionKeywords.Unlimited, StringComparison.OrdinalIgnoreCase) ||
+            input.Equals(SetupWizardConstants.RetentionKeywords.Forever, StringComparison.OrdinalIgnoreCase) ||
+            input == SetupWizardConstants.RetentionKeywords.Zero)
         {
             return Task.FromResult<int?>(-1); // -1 means unlimited
         }
@@ -236,7 +238,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
             return Task.FromResult<int?>(days);
         }
         
-        ShowWarning("Invalid input. Please enter a positive number or 'unlimited'. Using unlimited retention.");
+        ShowWarning($"Invalid input. Please enter a positive number or '{SetupWizardConstants.RetentionKeywords.Unlimited}'. Using unlimited retention.");
         return Task.FromResult<int?>(-1);
     }
 
@@ -252,7 +254,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         // Show SSH key display name, or fall back to key path, or "Not set"
         var sshKeyDisplay = settings.Ssh.KeyDisplayName 
             ?? settings.Ssh.KeyPath 
-            ?? "Not set";
+            ?? SetupWizardConstants.DisplayStrings.NotSet;
         
         table.AddRow("SSH Key", sshKeyDisplay.EscapeMarkup());
         table.AddRow("LLM Provider", settings.Llm.Provider.ToString());
@@ -262,8 +264,8 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         
         // Display retention: -1 or 0 means unlimited, otherwise show days
         var retentionDisplay = settings.Optional.RetentionDays <= 0 
-            ? "Unlimited (never delete)" 
-            : $"{settings.Optional.RetentionDays} days";
+            ? SetupWizardConstants.RetentionKeywords.UnlimitedDisplay 
+            : $"{settings.Optional.RetentionDays} {SetupWizardConstants.DisplayStrings.Days}";
         table.AddRow("Retention Days", retentionDisplay);
 
         _console.Write(new Rule("[yellow]Configuration Summary[/]"));
@@ -303,7 +305,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
     private static string MaskApiKey(string? apiKey)
     {
         if (string.IsNullOrEmpty(apiKey))
-            return "Not set";
+            return SetupWizardConstants.DisplayStrings.NotSet;
 
         if (apiKey.Length <= 4)
             return new string('*', apiKey.Length);

--- a/src/Shared/Constants/SetupWizardConstants.cs
+++ b/src/Shared/Constants/SetupWizardConstants.cs
@@ -1,0 +1,104 @@
+namespace TenSecondTom.Shared.Constants;
+
+/// <summary>
+/// Provides constants for the setup wizard UI to ensure consistency and avoid hardcoded strings.
+/// These constants are user-facing display strings.
+/// </summary>
+public static class SetupWizardConstants
+{
+    /// <summary>
+    /// Display suffixes and formatting for LLM provider choices in the setup wizard.
+    /// Uses LlmProviders constants as the source of truth for provider names.
+    /// </summary>
+    public static class ProviderDisplayNames
+    {
+        /// <summary>
+        /// Gets the display name for a provider (proper case).
+        /// Converts lowercase provider names from LlmProviders to display-friendly format.
+        /// </summary>
+        public static string GetDisplayName(string providerName)
+        {
+            return providerName.ToLowerInvariant() switch
+            {
+                LlmProviders.OpenAI => "OpenAI",
+                LlmProviders.Anthropic => "Anthropic",
+                _ => providerName // Fallback to original if unknown
+            };
+        }
+
+        public static string[] GetDisplayNames()
+        {
+            return LlmProviders.All
+                .Select(GetDisplayName)
+                .ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Display choices for logging levels in the setup wizard.
+    /// </summary>
+    public static class LogLevelDisplayNames
+    {
+        /// <summary>
+        /// Debug level display choice.
+        /// </summary>
+        public const string Debug = "Debug (verbose)";
+
+        /// <summary>
+        /// Information level display choice.
+        /// </summary>
+        public const string Information = "Information (recommended)";
+
+        /// <summary>
+        /// Warning level display choice.
+        /// </summary>
+        public const string Warning = "Warning (quiet)";
+
+        /// <summary>
+        /// Error level display choice.
+        /// </summary>
+        public const string Error = "Error (silent)";
+    }
+
+    /// <summary>
+    /// Keywords and values for retention policy configuration.
+    /// </summary>
+    public static class RetentionKeywords
+    {
+        /// <summary>
+        /// Keyword for unlimited retention.
+        /// </summary>
+        public const string Unlimited = "unlimited";
+
+        /// <summary>
+        /// Alternative keyword for unlimited retention.
+        /// </summary>
+        public const string Forever = "forever";
+
+        /// <summary>
+        /// Zero value treated as unlimited.
+        /// </summary>
+        public const string Zero = "0";
+
+        /// <summary>
+        /// Display string for unlimited retention in summary.
+        /// </summary>
+        public const string UnlimitedDisplay = "Unlimited (never delete)";
+    }
+
+    /// <summary>
+    /// Common display strings used throughout the setup wizard.
+    /// </summary>
+    public static class DisplayStrings
+    {
+        /// <summary>
+        /// Display string when a value is not set.
+        /// </summary>
+        public const string NotSet = "Not set";
+
+        /// <summary>
+        /// Display string for days unit in retention policy.
+        /// </summary>
+        public const string Days = "days";
+    }
+}

--- a/tests/TenSecondTom.Tests/Unit/Shared/Constants/SetupWizardConstantsTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Shared/Constants/SetupWizardConstantsTests.cs
@@ -1,0 +1,196 @@
+using FluentAssertions;
+using TenSecondTom.Shared.Constants;
+using Xunit;
+
+namespace TenSecondTom.Tests.Unit.Shared.Constants;
+
+/// <summary>
+/// Unit tests for SetupWizardConstants.
+/// Tests that all setup wizard UI constants are properly defined and consistent.
+/// </summary>
+public sealed class SetupWizardConstantsTests
+{
+    [Fact]
+    public void ProviderDisplayNames_GetDisplayName_WithOpenAI_ReturnsProperCase()
+    {
+        // Act
+        var result = SetupWizardConstants.ProviderDisplayNames.GetDisplayName(LlmProviders.OpenAI);
+
+        // Assert
+        result.Should().Be("OpenAI");
+    }
+
+    [Fact]
+    public void ProviderDisplayNames_GetDisplayName_WithAnthropic_ReturnsProperCase()
+    {
+        // Act
+        var result = SetupWizardConstants.ProviderDisplayNames.GetDisplayName(LlmProviders.Anthropic);
+
+        // Assert
+        result.Should().Be("Anthropic");
+    }
+
+    [Fact]
+    public void ProviderDisplayNames_GetDisplayName_WithUnknownProvider_ReturnsSameValue()
+    {
+        // Act
+        var result = SetupWizardConstants.ProviderDisplayNames.GetDisplayName("unknown");
+
+        // Assert
+        result.Should().Be("unknown");
+    }
+
+    [Fact]
+    public void ProviderDisplayNames_GetDisplayName_WithUppercaseInput_ReturnsProperCase()
+    {
+        // Act
+        var result = SetupWizardConstants.ProviderDisplayNames.GetDisplayName("OPENAI");
+
+        // Assert - should normalize to lowercase first, then map
+        result.Should().Be("OpenAI");
+    }
+
+    [Fact]
+    public void ProviderDisplayNames_OpenAIChoice_ShouldContainOpenAI()
+    {
+        // Assert
+        SetupWizardConstants.ProviderDisplayNames.GetDisplayNames().Should().Contain("OpenAI");
+    }
+
+    [Fact]
+    public void ProviderDisplayNames_AnthropicChoice_ShouldContainAnthropic()
+    {
+        // Assert
+        SetupWizardConstants.ProviderDisplayNames.GetDisplayNames().Should().Contain("Anthropic");
+    }
+
+    [Fact]
+    public void LogLevelDisplayNames_Debug_ShouldBeCorrectValue()
+    {
+        // Assert
+        SetupWizardConstants.LogLevelDisplayNames.Debug.Should().Be("Debug (verbose)");
+    }
+
+    [Fact]
+    public void LogLevelDisplayNames_Information_ShouldBeCorrectValue()
+    {
+        // Assert
+        SetupWizardConstants.LogLevelDisplayNames.Information.Should().Be("Information (recommended)");
+    }
+
+    [Fact]
+    public void LogLevelDisplayNames_Warning_ShouldBeCorrectValue()
+    {
+        // Assert
+        SetupWizardConstants.LogLevelDisplayNames.Warning.Should().Be("Warning (quiet)");
+    }
+
+    [Fact]
+    public void LogLevelDisplayNames_Error_ShouldBeCorrectValue()
+    {
+        // Assert
+        SetupWizardConstants.LogLevelDisplayNames.Error.Should().Be("Error (silent)");
+    }
+
+    [Fact]
+    public void RetentionKeywords_Unlimited_ShouldBeLowercase()
+    {
+        // Assert
+        SetupWizardConstants.RetentionKeywords.Unlimited.Should().Be("unlimited");
+    }
+
+    [Fact]
+    public void RetentionKeywords_Forever_ShouldBeLowercase()
+    {
+        // Assert
+        SetupWizardConstants.RetentionKeywords.Forever.Should().Be("forever");
+    }
+
+    [Fact]
+    public void RetentionKeywords_Zero_ShouldBeStringZero()
+    {
+        // Assert
+        SetupWizardConstants.RetentionKeywords.Zero.Should().Be("0");
+    }
+
+    [Fact]
+    public void RetentionKeywords_UnlimitedDisplay_ShouldBeUserFriendly()
+    {
+        // Assert
+        SetupWizardConstants.RetentionKeywords.UnlimitedDisplay.Should().Be("Unlimited (never delete)");
+    }
+
+    [Fact]
+    public void DisplayStrings_NotSet_ShouldBeCorrectValue()
+    {
+        // Assert
+        SetupWizardConstants.DisplayStrings.NotSet.Should().Be("Not set");
+    }
+
+    [Fact]
+    public void DisplayStrings_Days_ShouldBeCorrectValue()
+    {
+        // Assert
+        SetupWizardConstants.DisplayStrings.Days.Should().Be("days");
+    }
+
+    [Theory]
+    [InlineData("unlimited")]
+    [InlineData("forever")]
+    [InlineData("0")]
+    public void RetentionKeywords_AllUnlimitedVariants_ShouldBeDefined(string keyword)
+    {
+        // Arrange & Act
+        var allKeywords = new[]
+        {
+            SetupWizardConstants.RetentionKeywords.Unlimited,
+            SetupWizardConstants.RetentionKeywords.Forever,
+            SetupWizardConstants.RetentionKeywords.Zero
+        };
+
+        // Assert
+        allKeywords.Should().Contain(keyword);
+    }
+
+    [Fact]
+    public void ProviderDisplayNames_AllChoices_ShouldBeUnique()
+    {
+        // Arrange
+        var choices = new[]
+        {
+            SetupWizardConstants.ProviderDisplayNames.GetDisplayName(LlmProviders.OpenAI),
+            SetupWizardConstants.ProviderDisplayNames.GetDisplayName(LlmProviders.Anthropic)
+        };
+
+        // Assert
+        choices.Should().OnlyHaveUniqueItems();
+    }
+
+    [Theory]
+    [InlineData(LlmProviders.OpenAI, "OpenAI")]
+    [InlineData(LlmProviders.Anthropic, "Anthropic")]
+    public void ProviderDisplayNames_GetDisplayName_MapsCorrectly(string providerConstant, string expectedDisplay)
+    {
+        // Act
+        var result = SetupWizardConstants.ProviderDisplayNames.GetDisplayName(providerConstant);
+
+        // Assert
+        result.Should().Be(expectedDisplay);
+    }
+
+    [Fact]
+    public void LogLevelDisplayNames_AllChoices_ShouldBeUnique()
+    {
+        // Arrange
+        var choices = new[]
+        {
+            SetupWizardConstants.LogLevelDisplayNames.Debug,
+            SetupWizardConstants.LogLevelDisplayNames.Information,
+            SetupWizardConstants.LogLevelDisplayNames.Warning,
+            SetupWizardConstants.LogLevelDisplayNames.Error
+        };
+
+        // Assert
+        choices.Should().OnlyHaveUniqueItems();
+    }
+}


### PR DESCRIPTION
This pull request refactors the setup wizard UI to use a new centralized constants class for all user-facing display strings, replacing hardcoded values throughout the codebase. This improves maintainability and ensures consistency across prompts, summaries, and configuration options. Additionally, comprehensive unit tests are added to verify that these constants remain correct and unique.

Centralization of display strings and configuration keywords:

* Introduced `SetupWizardConstants` in `src/Shared/Constants/SetupWizardConstants.cs`, providing grouped constants for LLM provider names, log level choices, retention keywords, and other display strings used in the setup wizard UI.

Refactoring to use constants in the setup wizard handler:

* Updated `src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs` to replace all hardcoded strings for provider choices, log levels, retention keywords, directory names, and "not set" values with references to `SetupWizardConstants`. This affects prompt creation, summary display, and input parsing. [[1]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17R4) [[2]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L13-R19) [[3]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L82-R77) [[4]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L160-R161) [[5]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L179-R179) [[6]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L201-R204) [[7]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L216-R231) [[8]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L239-R241) [[9]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L255-R257) [[10]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L265-R268) [[11]](diffhunk://#diff-7e1782a57857f65d5a0d77bf06013a365633488c47c90901db7445bfdf415e17L306-R308)

Testing and validation:

* Added `SetupWizardConstantsTests` in `tests/TenSecondTom.Tests/Unit/Shared/Constants/SetupWizardConstantsTests.cs` to verify that all constant values are correct, properly mapped, and unique, covering provider display names, log levels, retention keywords, and display strings.