### PR TITLE
Implement audio configuration management with interactive promp…

### DIFF
--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -1,0 +1,50 @@
+# Scripts
+
+This directory contains utility scripts for the Ten Second Tom project.
+
+## cleanup-test-secrets.sh
+
+**Purpose**: Cleans up orphaned UserSecrets directories left behind by failed or interrupted tests.
+
+**Problem**: When integration tests fail, timeout, or are interrupted (Ctrl+C), they may leave behind temporary UserSecrets directories in `~/.microsoft/usersecrets/` with names like `TenSecondTom-Test-{guid}`. Over time, hundreds of these directories can accumulate.
+
+**Usage**:
+```bash
+# Preview what would be deleted
+.scripts/cleanup-test-secrets.sh --dry-run
+
+# Delete orphaned test directories
+.scripts/cleanup-test-secrets.sh
+
+# Show detailed output
+.scripts/cleanup-test-secrets.sh --dry-run --verbose
+
+# Get help
+.scripts/cleanup-test-secrets.sh --help
+```
+
+**Features**:
+- Cross-platform support (macOS, Linux, Windows via Git Bash)
+- Safe deletion with retry logic (3 attempts with 100ms delays)
+- Dry-run mode for preview
+- Verbose output for debugging
+- Colored output for better readability
+- Finds both naming patterns: `TenSecondTom-Test-*` and `tom-test-*`
+
+**When to Use**:
+- After interrupting tests with Ctrl+C
+- Before running tests to ensure clean state
+- Periodically to free up disk space
+- In CI/CD pipelines for cleanup
+
+**Exit Codes**:
+- `0`: Success (all directories deleted or none found)
+- `1`: Partial failure (some directories couldn't be deleted)
+
+**Related Documentation**:
+- Test cleanup patterns: `/tests/TenSecondTom.IntegrationTests/TestHelpers/README.md`
+- UserSecrets fixture: `/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsTestFixture.cs`
+
+---
+
+**Last Updated**: 2025-10-21

--- a/.scripts/cleanup-test-secrets.sh
+++ b/.scripts/cleanup-test-secrets.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# cleanup-test-secrets.sh
+# Cleanup script for orphaned test UserSecrets directories
+#
+# This script removes test UserSecrets directories that may be left behind
+# when tests fail, timeout, or are interrupted (Ctrl+C).
+#
+# Usage:
+#   .scripts/cleanup-test-secrets.sh [--dry-run] [--verbose]
+#
+# Options:
+#   --dry-run    Show what would be deleted without actually deleting
+#   --verbose    Show detailed output for each directory processed
+#
+# Examples:
+#   .scripts/cleanup-test-secrets.sh                    # Delete all test secrets
+#   .scripts/cleanup-test-secrets.sh --dry-run          # Preview what would be deleted
+#   .scripts/cleanup-test-secrets.sh --dry-run --verbose # Preview with details
+
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse command-line arguments
+DRY_RUN=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--dry-run] [--verbose]"
+            echo ""
+            echo "Cleanup script for orphaned test UserSecrets directories"
+            echo ""
+            echo "Options:"
+            echo "  --dry-run    Show what would be deleted without actually deleting"
+            echo "  --verbose    Show detailed output for each directory processed"
+            echo "  -h, --help   Show this help message"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option: $1${NC}" >&2
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Determine UserSecrets path based on OS
+if [[ "$OSTYPE" == "darwin"* ]] || [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # macOS and Linux
+    USER_SECRETS_DIR="$HOME/.microsoft/usersecrets"
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+    # Windows (Git Bash)
+    USER_SECRETS_DIR="$APPDATA/Microsoft/UserSecrets"
+else
+    echo -e "${RED}Error: Unsupported OS type: $OSTYPE${NC}" >&2
+    exit 1
+fi
+
+# Verify UserSecrets directory exists
+if [[ ! -d "$USER_SECRETS_DIR" ]]; then
+    echo -e "${YELLOW}UserSecrets directory not found: $USER_SECRETS_DIR${NC}"
+    echo "Nothing to clean up."
+    exit 0
+fi
+
+# Find all test directories (both TenSecondTom-Test-* and tom-test-* patterns)
+TEST_DIRS=()
+while IFS= read -r -d '' dir; do
+    TEST_DIRS+=("$dir")
+done < <(find "$USER_SECRETS_DIR" -maxdepth 1 -type d \( -name "TenSecondTom-Test-*" -o -name "tom-test-*" \) -print0 2>/dev/null || true)
+
+# Count directories
+DIR_COUNT=${#TEST_DIRS[@]}
+
+if [[ $DIR_COUNT -eq 0 ]]; then
+    echo -e "${GREEN}No orphaned test directories found. All clean!${NC}"
+    exit 0
+fi
+
+# Display header
+echo -e "${BLUE}Ten Second Tom - Test Secrets Cleanup${NC}"
+echo "=========================================="
+echo ""
+echo -e "Found ${YELLOW}$DIR_COUNT${NC} orphaned test director$([ $DIR_COUNT -eq 1 ] && echo "y" || echo "ies")"
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${YELLOW}DRY RUN MODE - Nothing will be deleted${NC}"
+    echo ""
+fi
+
+# Process each directory
+DELETED_COUNT=0
+FAILED_COUNT=0
+
+for dir in "${TEST_DIRS[@]}"; do
+    DIR_NAME=$(basename "$dir")
+    DIR_SIZE=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "unknown")
+
+    if [[ "$VERBOSE" == true ]]; then
+        echo -e "${BLUE}Processing:${NC} $DIR_NAME (${DIR_SIZE})"
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "  [DRY RUN] Would delete: $dir"
+        ((DELETED_COUNT++))
+    else
+        # Attempt deletion with retry logic
+        RETRY_COUNT=0
+        MAX_RETRIES=3
+        DELETED=false
+
+        while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            if rm -rf "$dir" 2>/dev/null; then
+                if [[ "$VERBOSE" == true ]]; then
+                    echo -e "  ${GREEN}✓${NC} Deleted successfully"
+                fi
+                ((DELETED_COUNT++))
+                DELETED=true
+                break
+            else
+                ((RETRY_COUNT++))
+                if [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
+                    if [[ "$VERBOSE" == true ]]; then
+                        echo -e "  ${YELLOW}⚠${NC} Retry $RETRY_COUNT/$MAX_RETRIES after 100ms delay..."
+                    fi
+                    sleep 0.1
+                fi
+            fi
+        done
+
+        if [[ "$DELETED" == false ]]; then
+            echo -e "  ${RED}✗${NC} Failed to delete: $DIR_NAME"
+            ((FAILED_COUNT++))
+        fi
+    fi
+done
+
+# Display summary
+echo ""
+echo "=========================================="
+echo -e "${BLUE}Summary${NC}"
+echo "=========================================="
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo -e "Would delete: ${YELLOW}$DELETED_COUNT${NC} director$([ $DELETED_COUNT -eq 1 ] && echo "y" || echo "ies")"
+else
+    echo -e "Successfully deleted: ${GREEN}$DELETED_COUNT${NC} director$([ $DELETED_COUNT -eq 1 ] && echo "y" || echo "ies")"
+
+    if [[ $FAILED_COUNT -gt 0 ]]; then
+        echo -e "Failed to delete: ${RED}$FAILED_COUNT${NC} director$([ $FAILED_COUNT -eq 1 ] && echo "y" || echo "ies")"
+        echo ""
+        echo -e "${YELLOW}Tip:${NC} Failed directories may be locked. Try:"
+        echo "  1. Close any running test processes"
+        echo "  2. Re-run this script"
+        echo "  3. Manually delete remaining directories if needed"
+    fi
+fi
+
+echo ""
+
+# Exit with appropriate code
+if [[ $FAILED_COUNT -gt 0 ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/sirkirby/ten-second-tom?sort=semver)
 [![brew install](https://img.shields.io/badge/brew_install-sirkirby/ten--second--tom/ten--second--tom-informational)](https://github.com/sirkirby/homebrew-ten-second-tom)
 
-
 ---
 
 ## ✨ Features
@@ -35,7 +34,6 @@
 - 🔐 **SSH Authentication**: Secure session management with SSH keys
 - 🎨 **Beautiful Terminal UI**: Rich formatting with Spectre.Console
 - 📤 **JSON Output**: Programmatic access for automation and integrations
-- 🔄 **Retry Mechanism**: Recover from failed AI summaries
 - ⏰ **Auto-Purge**: Configurable data retention policies
 
 ---

--- a/src/Features/Setup/DependencyInjection.cs
+++ b/src/Features/Setup/DependencyInjection.cs
@@ -40,7 +40,8 @@ public static class SetupFeatureExtensions
         
         // Configuration Storage
         services.AddSingleton<IConfigurationStorageService, UserSecretsStorageService>();
-        
+        services.AddSingleton<IAppSettingsStorageService, AppSettingsStorageService>();
+
         // Setup Wizard UI
         services.AddTransient<ISetupWizardUI, SpectreConsoleSetupWizard>();
         

--- a/src/Features/Setup/Handlers/ConfigCommandHandler.cs
+++ b/src/Features/Setup/Handlers/ConfigCommandHandler.cs
@@ -19,6 +19,7 @@ public sealed class ConfigCommandHandler
     private readonly IConfiguration _configuration;
     private readonly ISetupWizardUI _setupWizard;
     private readonly IEnumerable<IApiKeyValidator> _apiKeyValidators;
+    private readonly IAppSettingsStorageService _appSettingsStorage;
     private readonly ILogger<ConfigCommandHandler> _logger;
 
     public ConfigCommandHandler(
@@ -26,12 +27,14 @@ public sealed class ConfigCommandHandler
         IConfiguration configuration,
         ISetupWizardUI setupWizard,
         IEnumerable<IApiKeyValidator> apiKeyValidators,
+        IAppSettingsStorageService appSettingsStorage,
         ILogger<ConfigCommandHandler> logger)
     {
         _storageService = storageService ?? throw new ArgumentNullException(nameof(storageService));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _setupWizard = setupWizard ?? throw new ArgumentNullException(nameof(setupWizard));
         _apiKeyValidators = apiKeyValidators ?? throw new ArgumentNullException(nameof(apiKeyValidators));
+        _appSettingsStorage = appSettingsStorage ?? throw new ArgumentNullException(nameof(appSettingsStorage));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -211,6 +214,12 @@ public sealed class ConfigCommandHandler
         if (command.SettingName.Equals("llm", StringComparison.OrdinalIgnoreCase))
         {
             return await HandleInteractiveLlmConfigurationAsync(cancellationToken);
+        }
+
+        // Special handling for "audio" - interactive configuration
+        if (command.SettingName.Equals("audio", StringComparison.OrdinalIgnoreCase))
+        {
+            return await HandleInteractiveAudioConfigurationAsync(cancellationToken);
         }
 
         if (string.IsNullOrWhiteSpace(command.SettingValue))
@@ -528,6 +537,217 @@ public sealed class ConfigCommandHandler
         _setupWizard.ShowSuccess($"✓ LLM configuration updated: {providerName} - {selectedModel.DisplayName} [{selectedModel.CostTier}]");
 
         return Result<ConfigurationSettings>.Success(markedConfig);
+    }
+
+    private async Task<Result<ConfigurationSettings>> HandleInteractiveAudioConfigurationAsync(
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting interactive audio configuration");
+
+        // Load current audio configuration from appsettings.json
+        var loadResult = await _appSettingsStorage.LoadAudioConfigurationAsync(cancellationToken);
+
+        if (!loadResult.IsSuccess)
+        {
+            _setupWizard.ShowWarning("Could not load current audio configuration. Using defaults.");
+        }
+
+        var currentAudio = loadResult.IsSuccess ? loadResult.Value! : new AudioConfiguration();
+
+        const int totalSteps = 9;
+
+        // Step 1: Input Volume
+        _setupWizard.ShowStepHeader(1, totalSteps, "Input Volume");
+        var inputVolume = await _setupWizard.PromptForInputVolumeAsync(
+            currentAudio.Recorder.InputVolume,
+            cancellationToken);
+
+        if (!inputVolume.HasValue)
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Step 2: Noise Reduction
+        _setupWizard.ShowStepHeader(2, totalSteps, "Noise Reduction");
+        var noiseReduction = await _setupWizard.PromptForBooleanAsync(
+            "Enable noise reduction during recording?",
+            currentAudio.Recorder.EnableNoiseReduction,
+            cancellationToken);
+
+        if (!noiseReduction.HasValue)
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Step 3: Frequency Filters
+        _setupWizard.ShowStepHeader(3, totalSteps, "Frequency Filters");
+        var frequencyFilters = await _setupWizard.PromptForBooleanAsync(
+            "Enable frequency filters during recording?",
+            currentAudio.Recorder.EnableFrequencyFilters,
+            cancellationToken);
+
+        if (!frequencyFilters.HasValue)
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Step 4: Silence Removal
+        _setupWizard.ShowStepHeader(4, totalSteps, "Silence Removal");
+        var removeSilence = await _setupWizard.PromptForBooleanAsync(
+            "Remove silence from recordings during preprocessing?",
+            currentAudio.Preprocessing.RemoveSilence,
+            cancellationToken);
+
+        if (!removeSilence.HasValue)
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Step 5: Silence Threshold (only if silence removal enabled)
+        int silenceThresholdDb = currentAudio.Preprocessing.SilenceThresholdDb;
+        if (removeSilence.Value)
+        {
+            _setupWizard.ShowStepHeader(5, totalSteps, "Silence Detection Threshold");
+            var threshold = await _setupWizard.PromptForIntAsync(
+                "Silence threshold in decibels (-60 to -40):",
+                currentAudio.Preprocessing.SilenceThresholdDb,
+                -60,
+                -40,
+                cancellationToken);
+
+            if (!threshold.HasValue)
+            {
+                return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+            }
+            silenceThresholdDb = threshold.Value;
+        }
+        else
+        {
+            _setupWizard.ShowStepHeader(5, totalSteps, "Silence Detection Threshold");
+            _setupWizard.ShowStatus("Skipped (silence removal disabled)");
+        }
+
+        // Step 6: Minimum Silence Duration (only if silence removal enabled)
+        int minSilenceDurationMs = currentAudio.Preprocessing.MinimumSilenceDurationMs;
+        if (removeSilence.Value)
+        {
+            _setupWizard.ShowStepHeader(6, totalSteps, "Minimum Silence Duration");
+            var duration = await _setupWizard.PromptForIntAsync(
+                "Minimum silence duration to remove (ms, 100-2000):",
+                currentAudio.Preprocessing.MinimumSilenceDurationMs,
+                100,
+                2000,
+                cancellationToken);
+
+            if (!duration.HasValue)
+            {
+                return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+            }
+            minSilenceDurationMs = duration.Value;
+        }
+        else
+        {
+            _setupWizard.ShowStepHeader(6, totalSteps, "Minimum Silence Duration");
+            _setupWizard.ShowStatus("Skipped (silence removal disabled)");
+        }
+
+        // Step 7: Preferred STT Engine
+        _setupWizard.ShowStepHeader(7, totalSteps, "Speech-to-Text Engine");
+        var preferredStt = await _setupWizard.PromptForSttPreferenceAsync(
+            currentAudio.PreferredStt,
+            cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(preferredStt))
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Step 8: Today Voice Timeout
+        _setupWizard.ShowStepHeader(8, totalSteps, "Today Voice Recording Timeout");
+        _setupWizard.ShowStatus("When this duration is reached, you'll be prompted to continue or finish recording.");
+        var todayTimeout = await _setupWizard.PromptForIntAsync(
+            "Time before prompting to continue 'today --voice' (seconds, 30-600):",
+            currentAudio.Timeouts.TodaySeconds,
+            30,
+            600,
+            cancellationToken);
+
+        if (!todayTimeout.HasValue)
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Step 9: Record Command Timeout
+        _setupWizard.ShowStepHeader(9, totalSteps, "Record Command Timeout");
+        _setupWizard.ShowStatus("When this duration is reached, you'll be prompted to continue or finish recording.");
+        var recordTimeout = await _setupWizard.PromptForIntAsync(
+            "Time before prompting to continue 'record' (seconds, 60-1800):",
+            currentAudio.Timeouts.RecordSeconds,
+            60,
+            1800,
+            cancellationToken);
+
+        if (!recordTimeout.HasValue)
+        {
+            return Result<ConfigurationSettings>.Failure("Audio configuration cancelled. No changes were made.");
+        }
+
+        // Build updated audio configuration
+        var updatedAudio = new AudioConfiguration
+        {
+            PreferredStt = preferredStt,
+            KeepFiles = currentAudio.KeepFiles, // Not modified interactively
+            Recorder = new RecorderConfiguration
+            {
+                FfmpegPath = currentAudio.Recorder.FfmpegPath, // Not modified interactively
+                InputVolume = inputVolume.Value,
+                EnableNoiseReduction = noiseReduction.Value,
+                EnableFrequencyFilters = frequencyFilters.Value
+            },
+            LocalWhisper = currentAudio.LocalWhisper, // Not modified interactively
+            Preprocessing = new PreprocessingConfiguration
+            {
+                RemoveSilence = removeSilence.Value,
+                SilenceThresholdDb = silenceThresholdDb,
+                MinimumSilenceDurationMs = minSilenceDurationMs
+            },
+            Timeouts = new RecordingTimeoutsConfiguration
+            {
+                TodaySeconds = todayTimeout.Value,
+                RecordSeconds = recordTimeout.Value
+            }
+        };
+
+        // Save to appsettings.json
+        var saveResult = await _appSettingsStorage.SaveAudioConfigurationAsync(updatedAudio, cancellationToken);
+
+        if (!saveResult.IsSuccess)
+        {
+            return Result<ConfigurationSettings>.Failure($"Failed to save audio configuration: {saveResult.Error}. Changes were not applied.");
+        }
+
+        _logger.LogInformation("Audio configuration updated successfully");
+
+        // Display success message with summary
+        _setupWizard.ShowSuccess("✓ Audio configuration saved successfully");
+        _setupWizard.ShowStatus($"  • Input volume: {inputVolume.Value:F1}");
+        _setupWizard.ShowStatus($"  • Noise reduction: {(noiseReduction.Value ? "Enabled" : "Disabled")}");
+        _setupWizard.ShowStatus($"  • Frequency filters: {(frequencyFilters.Value ? "Enabled" : "Disabled")}");
+        _setupWizard.ShowStatus($"  • Silence removal: {(removeSilence.Value ? "Enabled" : "Disabled")}");
+        if (removeSilence.Value)
+        {
+            _setupWizard.ShowStatus($"  • Silence threshold: {silenceThresholdDb} dB");
+            _setupWizard.ShowStatus($"  • Min silence duration: {minSilenceDurationMs} ms");
+        }
+        _setupWizard.ShowStatus($"  • Preferred STT: {preferredStt}");
+        _setupWizard.ShowStatus($"  • Today timeout: {todayTimeout.Value}s");
+        _setupWizard.ShowStatus($"  • Record timeout: {recordTimeout.Value}s");
+
+        // Return current configuration (audio config is stored separately in appsettings.json)
+        var configLoadResult = await _storageService.LoadAsync(cancellationToken);
+        return configLoadResult.IsSuccess
+            ? Result<ConfigurationSettings>.Success(configLoadResult.Value!)
+            : Result<ConfigurationSettings>.Failure("Audio configuration saved, but could not reload main configuration.");
     }
 
     private Task<Result<ConfigurationSettings>> HandleResetAsync(CancellationToken cancellationToken)

--- a/src/Features/Setup/Handlers/ISetupWizardUI.cs
+++ b/src/Features/Setup/Handlers/ISetupWizardUI.cs
@@ -95,4 +95,52 @@ public interface ISetupWizardUI
     /// Shows a warning message
     /// </summary>
     void ShowWarning(string message);
+
+    /// <summary>
+    /// Prompts user to enter input volume multiplier
+    /// </summary>
+    /// <param name="currentValue">Current input volume value</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Selected volume, or null if cancelled</returns>
+    Task<double?> PromptForInputVolumeAsync(
+        double? currentValue,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Prompts user for a boolean setting with enable/disable options
+    /// </summary>
+    /// <param name="prompt">The question to ask the user</param>
+    /// <param name="currentValue">Current boolean value</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Selected boolean value, or null if cancelled</returns>
+    Task<bool?> PromptForBooleanAsync(
+        string prompt,
+        bool? currentValue,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Prompts user to enter an integer value within a range
+    /// </summary>
+    /// <param name="prompt">The question to ask the user</param>
+    /// <param name="currentValue">Current integer value</param>
+    /// <param name="min">Minimum allowed value</param>
+    /// <param name="max">Maximum allowed value</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Selected integer, or null if cancelled</returns>
+    Task<int?> PromptForIntAsync(
+        string prompt,
+        int? currentValue,
+        int min,
+        int max,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Prompts user to select preferred STT engine
+    /// </summary>
+    /// <param name="currentValue">Current STT preference (auto/local/openai)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Selected STT preference, or null if cancelled</returns>
+    Task<string?> PromptForSttPreferenceAsync(
+        string? currentValue,
+        CancellationToken cancellationToken);
 }

--- a/src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs
+++ b/src/Features/Setup/Handlers/SpectreConsoleSetupWizard.cs
@@ -302,6 +302,106 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
         _console.MarkupLine($"[yellow]⚠️  {message.EscapeMarkup()}[/]");
     }
 
+    public Task<double?> PromptForInputVolumeAsync(
+        double? currentValue,
+        CancellationToken cancellationToken)
+    {
+        _console.MarkupLine("[grey]ℹ️  Input volume multiplier (0.0 to 2.0)[/]");
+        _console.MarkupLine("[grey]   • Laptop/built-in mics: 1.0-1.2[/]");
+        _console.MarkupLine("[grey]   • Dynamic mics (SM7B): 0.7-0.8[/]");
+        _console.MarkupLine("[grey]   • Condenser/USB mics: 0.9-1.0[/]");
+        _console.WriteLine();
+
+        var prompt = new TextPrompt<string>("Enter input volume (0.0 - 2.0):")
+            .DefaultValue((currentValue ?? 1.0).ToString("0.0", System.Globalization.CultureInfo.InvariantCulture))
+            .Validate(input =>
+            {
+                if (double.TryParse(input, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var volume))
+                {
+                    if (volume >= 0.0 && volume <= 2.0)
+                        return Spectre.Console.ValidationResult.Success();
+                    return Spectre.Console.ValidationResult.Error("[red]Volume must be between 0.0 and 2.0[/]");
+                }
+                return Spectre.Console.ValidationResult.Error("[red]Please enter a valid number[/]");
+            });
+
+        var input = _console.Prompt(prompt);
+        if (double.TryParse(input, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var result))
+        {
+            return Task.FromResult<double?>(result);
+        }
+
+        return Task.FromResult<double?>(null);
+    }
+
+    public Task<bool?> PromptForBooleanAsync(
+        string prompt,
+        bool? currentValue,
+        CancellationToken cancellationToken)
+    {
+        var choices = new[] { "Enabled", "Disabled" };
+        var defaultChoice = (currentValue ?? true) ? "Enabled" : "Disabled";
+
+        var selectionPrompt = new SelectionPrompt<string>()
+            .Title(prompt)
+            .AddChoices(choices);
+
+        var selected = _console.Prompt(selectionPrompt);
+        return Task.FromResult<bool?>(selected == "Enabled");
+    }
+
+    public Task<int?> PromptForIntAsync(
+        string prompt,
+        int? currentValue,
+        int min,
+        int max,
+        CancellationToken cancellationToken)
+    {
+        var textPrompt = new TextPrompt<string>(prompt)
+            .DefaultValue((currentValue ?? min).ToString(System.Globalization.CultureInfo.InvariantCulture))
+            .Validate(input =>
+            {
+                if (int.TryParse(input, out var value))
+                {
+                    if (value >= min && value <= max)
+                        return Spectre.Console.ValidationResult.Success();
+                    return Spectre.Console.ValidationResult.Error($"[red]Value must be between {min} and {max}[/]");
+                }
+                return Spectre.Console.ValidationResult.Error("[red]Please enter a valid integer[/]");
+            });
+
+        var input = _console.Prompt(textPrompt);
+        if (int.TryParse(input, out var result))
+        {
+            return Task.FromResult<int?>(result);
+        }
+
+        return Task.FromResult<int?>(null);
+    }
+
+    public Task<string?> PromptForSttPreferenceAsync(
+        string? currentValue,
+        CancellationToken cancellationToken)
+    {
+        _console.MarkupLine("[grey]ℹ️  Speech-to-Text engine preference:[/]");
+        _console.MarkupLine("[grey]   • auto: Try local (whisper.cpp) first, fallback to OpenAI[/]");
+        _console.MarkupLine("[grey]   • local: Always use whisper.cpp (requires installation)[/]");
+        _console.MarkupLine("[grey]   • openai: Always use OpenAI Whisper API[/]");
+        _console.WriteLine();
+
+        var choices = new[] { "auto", "local", "openai" };
+        var defaultChoice = currentValue ?? "auto";
+
+        var prompt = new SelectionPrompt<string>()
+            .Title("Select STT preference:")
+            .AddChoices(choices);
+
+        var selected = _console.Prompt(prompt);
+        return Task.FromResult<string?>(selected);
+    }
+
     private static string MaskApiKey(string? apiKey)
     {
         if (string.IsNullOrEmpty(apiKey))

--- a/src/Infrastructure/Cli/CommandRegistry.cs
+++ b/src/Infrastructure/Cli/CommandRegistry.cs
@@ -490,6 +490,12 @@ public static class CommandRegistry
                 return 1;
             }
 
+            // Show recording prompt (unless in JSON mode)
+            if (!jsonOutput)
+            {
+                AnsiConsole.MarkupLine("[cyan]🎤 Recording... Press Enter to stop.[/]");
+            }
+
             // Execute command with configured timeout
             var command = new TenSecondTom.Features.Audio.Commands.RecordCommand
             {
@@ -522,9 +528,32 @@ public static class CommandRegistry
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine($"[green]✓[/] Recording saved to: [cyan]{recording.AudioFilePath.EscapeMarkup()}[/]");
-                    AnsiConsole.MarkupLine($"[green]✓[/] Transcription saved to: [cyan]{recording.TranscriptionFilePath.EscapeMarkup()}[/]");
-                    AnsiConsole.MarkupLine($"[dim]Duration:[/] {recording.Duration.TotalSeconds:F1}s | [dim]Words:[/] {recording.TranscriptionWordCount} | [dim]Engine:[/] {recording.SttEngine} ({recording.SttModel ?? "default"})");
+                    AnsiConsole.MarkupLine($"[green]✓[/] Recording complete ({recording.Duration.TotalSeconds:F1}s)");
+                    AnsiConsole.MarkupLine($"[green]✓[/] Transcription complete ({recording.TranscriptionWordCount} words, {recording.SttEngine})");
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine("[bold]Transcript:[/]");
+
+                    // Read and display the transcription text (strip YAML frontmatter)
+                    var transcriptContent = File.ReadAllText(recording.TranscriptionFilePath);
+                    var lines = transcriptContent.Split('\n');
+                    bool inFrontmatter = false;
+                    var transcriptText = new System.Text.StringBuilder();
+                    foreach (var line in lines)
+                    {
+                        if (line.Trim() == "---")
+                        {
+                            inFrontmatter = !inFrontmatter;
+                            continue;
+                        }
+                        if (!inFrontmatter && !string.IsNullOrWhiteSpace(line))
+                        {
+                            transcriptText.AppendLine(line);
+                        }
+                    }
+
+                    AnsiConsole.MarkupLine($"[dim]{transcriptText.ToString().Trim().EscapeMarkup()}[/]");
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine($"[dim]Audio saved: {recording.AudioFilePath.EscapeMarkup()}[/]");
                 }
                 return 0;
             }
@@ -873,9 +902,57 @@ public static class CommandRegistry
             }
         });
 
+        // Audio subcommand - interactive configuration for audio recording and processing
+        var audioCommand = new Command("audio", "Configure audio recording and processing settings interactively");
+        audioCommand.Options.Add(jsonOutputOption);
+
+        audioCommand.SetAction(async (parseResult) =>
+        {
+            bool jsonOutput = parseResult.GetValue(jsonOutputOption);
+
+            var handler = serviceProvider.GetRequiredService<ConfigCommandHandler>();
+
+            var command = new ConfigCommand
+            {
+                Action = ConfigAction.Set,
+                SettingName = "audio",
+                SettingValue = null,
+                ShowSecrets = false
+            };
+
+            var result = await handler.Handle(command, CancellationToken.None).ConfigureAwait(false);
+
+            if (result.IsSuccess)
+            {
+                if (jsonOutput)
+                {
+                    AnsiConsole.WriteLine(System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        message = "Audio configuration updated successfully"
+                    }));
+                }
+                // Success message already displayed by handler
+                return 0;
+            }
+            else
+            {
+                if (jsonOutput)
+                {
+                    AnsiConsole.WriteLine(System.Text.Json.JsonSerializer.Serialize(new { success = false, error = result.Error }));
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine($"[red]✗[/] {result.Error.EscapeMarkup()}");
+                }
+                return 1;
+            }
+        });
+
         configCommand.Subcommands.Add(showCommand);
         configCommand.Subcommands.Add(setCommand);
         configCommand.Subcommands.Add(llmCommand);
+        configCommand.Subcommands.Add(audioCommand);
         configCommand.Subcommands.Add(validateCommand);
 
         return configCommand;

--- a/src/Infrastructure/Configuration/AppSettingsStorageService.cs
+++ b/src/Infrastructure/Configuration/AppSettingsStorageService.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using TenSecondTom.Shared.Constants;
+using TenSecondTom.Shared.Results;
+
+namespace TenSecondTom.Infrastructure.Configuration;
+
+/// <summary>
+/// Service for managing appsettings.json file updates.
+/// Provides atomic updates with proper error handling and file locking.
+/// </summary>
+public sealed class AppSettingsStorageService : IAppSettingsStorageService, IDisposable
+{
+    private readonly ILogger<AppSettingsStorageService> _logger;
+    private readonly string _appSettingsPath;
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
+    private bool _disposed;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    public AppSettingsStorageService(
+        ILogger<AppSettingsStorageService> logger,
+        string? appSettingsPath = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _appSettingsPath = appSettingsPath ?? Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+    }
+
+    public async Task<Result<string>> SaveAudioConfigurationAsync(
+        AudioConfiguration audioConfig,
+        CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            _logger.LogInformation("Saving audio configuration to {Path}", _appSettingsPath);
+
+            // Load existing JSON or create new
+            JsonDocument? existingDoc = null;
+            if (File.Exists(_appSettingsPath))
+            {
+                try
+                {
+                    var existingJson = await File.ReadAllTextAsync(_appSettingsPath, cancellationToken);
+                    existingDoc = JsonDocument.Parse(existingJson);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Existing appsettings.json is invalid, creating new file");
+                }
+            }
+
+            // Build new JSON structure
+            var root = new Dictionary<string, object>();
+
+            // Preserve existing TenSecondTom section
+            if (existingDoc != null && existingDoc.RootElement.TryGetProperty(ConfigurationKeys.Root, out var tenSecondTomSection))
+            {
+                root[ConfigurationKeys.Root] = JsonSerializer.Deserialize<Dictionary<string, object>>(tenSecondTomSection.GetRawText())
+                    ?? new Dictionary<string, object>();
+            }
+            else
+            {
+                root[ConfigurationKeys.Root] = new Dictionary<string, object>();
+            }
+
+            // Update audio section
+            var tenSecondTom = (Dictionary<string, object>)root[ConfigurationKeys.Root];
+            tenSecondTom["Audio"] = new
+            {
+                PreferredStt = audioConfig.PreferredStt,
+                KeepFiles = audioConfig.KeepFiles,
+                Recorder = new
+                {
+                    FfmpegPath = audioConfig.Recorder.FfmpegPath,
+                    InputVolume = audioConfig.Recorder.InputVolume,
+                    EnableNoiseReduction = audioConfig.Recorder.EnableNoiseReduction,
+                    EnableFrequencyFilters = audioConfig.Recorder.EnableFrequencyFilters
+                },
+                LocalWhisper = new
+                {
+                    BinaryPath = audioConfig.LocalWhisper.BinaryPath,
+                    ModelPath = audioConfig.LocalWhisper.ModelPath
+                },
+                Preprocessing = new
+                {
+                    RemoveSilence = audioConfig.Preprocessing.RemoveSilence,
+                    SilenceThresholdDb = audioConfig.Preprocessing.SilenceThresholdDb,
+                    MinimumSilenceDurationMs = audioConfig.Preprocessing.MinimumSilenceDurationMs
+                },
+                Timeouts = new
+                {
+                    TodaySeconds = audioConfig.Timeouts.TodaySeconds,
+                    RecordSeconds = audioConfig.Timeouts.RecordSeconds
+                }
+            };
+
+            // Write atomically (temp file + rename)
+            var tempPath = _appSettingsPath + ".tmp";
+            var json = JsonSerializer.Serialize(root, JsonOptions);
+            await File.WriteAllTextAsync(tempPath, json, cancellationToken);
+
+            // Atomic replace
+            File.Move(tempPath, _appSettingsPath, overwrite: true);
+
+            _logger.LogInformation("Audio configuration saved successfully");
+            return Result<string>.Success(_appSettingsPath);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save audio configuration");
+            return Result<string>.Failure($"Failed to save audio configuration: {ex.Message}");
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    public async Task<Result<AudioConfiguration>> LoadAudioConfigurationAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _fileLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!File.Exists(_appSettingsPath))
+            {
+                _logger.LogInformation("appsettings.json not found, returning default configuration");
+                return Result<AudioConfiguration>.Success(new AudioConfiguration());
+            }
+
+            var json = await File.ReadAllTextAsync(_appSettingsPath, cancellationToken);
+            using var doc = JsonDocument.Parse(json);
+
+            // Navigate to TenSecondTom:Audio section
+            if (!doc.RootElement.TryGetProperty(ConfigurationKeys.Root, out var tenSecondTomSection))
+            {
+                return Result<AudioConfiguration>.Success(new AudioConfiguration());
+            }
+
+            if (!tenSecondTomSection.TryGetProperty("Audio", out var audioSection))
+            {
+                return Result<AudioConfiguration>.Success(new AudioConfiguration());
+            }
+
+            // Deserialize audio configuration
+            var audioConfig = JsonSerializer.Deserialize<AudioConfiguration>(audioSection.GetRawText(), JsonOptions);
+
+            return Result<AudioConfiguration>.Success(audioConfig ?? new AudioConfiguration());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load audio configuration");
+            return Result<AudioConfiguration>.Failure($"Failed to load audio configuration: {ex.Message}");
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _fileLock.Dispose();
+            _disposed = true;
+        }
+    }
+}

--- a/src/Infrastructure/Configuration/IAppSettingsStorageService.cs
+++ b/src/Infrastructure/Configuration/IAppSettingsStorageService.cs
@@ -1,0 +1,29 @@
+using TenSecondTom.Infrastructure.Configuration;
+using TenSecondTom.Shared.Results;
+
+namespace TenSecondTom.Infrastructure.Configuration;
+
+/// <summary>
+/// Interface for managing appsettings.json file updates.
+/// Provides atomic updates to audio configuration sections.
+/// </summary>
+public interface IAppSettingsStorageService
+{
+    /// <summary>
+    /// Updates the audio configuration section in appsettings.json.
+    /// </summary>
+    /// <param name="audioConfig">Audio configuration to save</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Result containing the file path where configuration was saved</returns>
+    Task<Result<string>> SaveAudioConfigurationAsync(
+        AudioConfiguration audioConfig,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the current audio configuration from appsettings.json.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Result containing the audio configuration or an error</returns>
+    Task<Result<AudioConfiguration>> LoadAudioConfigurationAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/ConfigLlmCommandTests.cs
+++ b/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/ConfigLlmCommandTests.cs
@@ -8,6 +8,7 @@ using TenSecondTom.Features.Setup.Handlers;
 using TenSecondTom.Features.Setup.Models;
 using TenSecondTom.Features.Setup.Validation;
 using TenSecondTom.Infrastructure.Configuration;
+using TenSecondTom.IntegrationTests.TestHelpers;
 using TenSecondTom.Shared.Results;
 
 namespace TenSecondTom.IntegrationTests.Integration.Features.Setup;
@@ -16,15 +17,14 @@ namespace TenSecondTom.IntegrationTests.Integration.Features.Setup;
 /// Integration tests for 'tom config llm' command flow
 /// Tests end-to-end interactive model selection via config command
 /// </summary>
-public sealed class ConfigLlmCommandTests : IDisposable
+[Collection(UserSecretsCollection.Name)]
+public sealed class ConfigLlmCommandTests : UserSecretsTestFixture
 {
     private readonly ServiceProvider _serviceProvider;
-    private readonly string _testSecretsId;
     private readonly Mock<ISetupWizardUI> _mockWizard;
 
     public ConfigLlmCommandTests()
     {
-        _testSecretsId = $"tom-test-{Guid.NewGuid()}";
         _mockWizard = new Mock<ISetupWizardUI>();
 
         // Setup common UI methods that don't affect test outcomes
@@ -32,26 +32,35 @@ public sealed class ConfigLlmCommandTests : IDisposable
         _mockWizard.Setup(w => w.ShowWarning(It.IsAny<string>()));
 
         var services = new ServiceCollection();
-        
+
         services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
         services.AddHttpClient(); // Required by API key validators
         services.AddSingleton(_mockWizard.Object);
+
+        // Use TestUserSecretsId from base fixture
         services.AddSingleton<IConfigurationStorageService>(sp =>
             new UserSecretsStorageService(
                 sp.GetRequiredService<ILogger<UserSecretsStorageService>>(),
-                _testSecretsId));
-        
+                TestUserSecretsId));
+
+        // Mock app settings storage (not tested in these LLM config tests)
+        var mockAppSettingsStorage = new Mock<IAppSettingsStorageService>();
+        services.AddSingleton(mockAppSettingsStorage.Object);
+
         // Add IConfiguration with empty configuration (no overrides)
         var configBuilder = new ConfigurationBuilder();
         services.AddSingleton<IConfiguration>(configBuilder.Build());
-        
+
         // Add required validators for ConfigCommandHandler
         services.AddTransient<IApiKeyValidator, OpenAIApiKeyValidator>();
         services.AddTransient<IApiKeyValidator, AnthropicApiKeyValidator>();
-        
+
         services.AddTransient<ConfigCommandHandler>();
 
         _serviceProvider = services.BuildServiceProvider();
+
+        // Set up logger for the base fixture
+        Logger = _serviceProvider.GetRequiredService<ILogger<UserSecretsTestFixture>>();
     }
 
     [Fact]
@@ -317,32 +326,13 @@ public sealed class ConfigLlmCommandTests : IDisposable
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    public void Dispose()
+    public override async Task DisposeAsync()
     {
-        // Cleanup test user secrets if created
-        var userSecretsPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Microsoft",
-            "UserSecrets",
-            _testSecretsId);
-        
-        if (Directory.Exists(userSecretsPath))
-        {
-            try
-            {
-                Directory.Delete(userSecretsPath, recursive: true);
-            }
-            catch (IOException)
-            {
-                // Best effort cleanup - directory may be in use
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // Best effort cleanup - permissions issue
-            }
-        }
-        
+        // Dispose service provider
         _serviceProvider?.Dispose();
+
+        // Call base cleanup for UserSecrets
+        await base.DisposeAsync();
     }
 
     private static ConfigurationSettings CreateValidConfiguration()

--- a/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/ConfigurationValidationTests.cs
+++ b/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/ConfigurationValidationTests.cs
@@ -257,11 +257,15 @@ public sealed class ConfigurationValidationTests : IDisposable
         // Mock configuration storage
         var mockStorage = new Mock<IConfigurationStorageService>();
         services.AddSingleton(mockStorage.Object);
-        
+
+        // Mock app settings storage
+        var mockAppSettingsStorage = new Mock<IAppSettingsStorageService>();
+        services.AddSingleton(mockAppSettingsStorage.Object);
+
         // Add IConfiguration with empty configuration (no overrides)
         var configBuilder = new ConfigurationBuilder();
         services.AddSingleton<IConfiguration>(configBuilder.Build());
-        
+
         // Mock ISetupWizardUI (required by ConfigCommandHandler)
         var mockWizard = new Mock<ISetupWizardUI>();
         services.AddSingleton(mockWizard.Object);

--- a/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/EnvironmentVariableConfigTests.cs
+++ b/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/EnvironmentVariableConfigTests.cs
@@ -16,51 +16,28 @@ namespace TenSecondTom.IntegrationTests.Integration.Features.Setup;
 /// Tests User Story 3: Model Configuration via Environment Variables
 /// Verifies that environment variables override user secrets in the configuration hierarchy.
 /// </summary>
-public sealed class EnvironmentVariableConfigTests : IDisposable
+[Collection(UserSecretsCollection.Name)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "IAsyncLifetime pattern used instead of IDisposable")]
+public sealed class EnvironmentVariableConfigTests : UserSecretsTestFixture
 {
     private readonly TemporaryTestDirectory _testDirectory;
-    private readonly string _testUserSecretsId;
 
     public EnvironmentVariableConfigTests()
     {
         _testDirectory = new TemporaryTestDirectory();
-        _testUserSecretsId = $"TenSecondTom-Test-EnvVar-{Guid.NewGuid()}";
+
+        // Set up logger for the base fixture
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        Logger = loggerFactory.CreateLogger<UserSecretsTestFixture>();
     }
 
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Cleanup must not throw")]
-    public void Dispose()
+    public override async Task DisposeAsync()
     {
         _testDirectory.Dispose();
-        
-        var userSecretsPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Microsoft",
-            "UserSecrets",
-            _testUserSecretsId);
 
-        if (Directory.Exists(userSecretsPath))
-        {
-            try
-            {
-                Directory.Delete(userSecretsPath, recursive: true);
-            }
-            catch (IOException)
-            {
-                Thread.Sleep(100);
-                try
-                {
-                    Directory.Delete(userSecretsPath, recursive: true);
-                }
-                catch
-                {
-                    // Ignore cleanup errors
-                }
-            }
-            catch
-            {
-                // Ignore cleanup errors
-            }
-        }
+        // Call base cleanup for UserSecrets
+        await base.DisposeAsync();
     }
 
     [Fact]
@@ -87,7 +64,7 @@ public sealed class EnvironmentVariableConfigTests : IDisposable
 
         // Act - Build configuration with environment variable override
         // Simulate loading from user secrets file, then override with environment variable
-        var userSecretsPath = SecretsHelper.GetUserSecretsPath(_testUserSecretsId);
+        var userSecretsPath = SecretsHelper.GetUserSecretsPath(TestUserSecretsId);
         
         var configWithEnvOverride = new ConfigurationBuilder()
             .AddJsonFile(userSecretsPath, optional: true)
@@ -265,21 +242,21 @@ public sealed class EnvironmentVariableConfigTests : IDisposable
     private ServiceProvider BuildTestServiceProvider()
     {
         var services = new ServiceCollection();
-        
-        // Configure with test user secrets ID
-        var userSecretsPath = SecretsHelper.GetUserSecretsPath(_testUserSecretsId);
+
+        // Configure with test user secrets ID from base fixture
+        var userSecretsPath = SecretsHelper.GetUserSecretsPath(TestUserSecretsId);
         var configuration = new ConfigurationBuilder()
             .AddJsonFile(userSecretsPath, optional: true)
             .Build();
 
         services.AddSingleton<IConfiguration>(configuration);
         services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
-        
+
         // Register storage service with test configuration
         services.AddSingleton<IConfigurationStorageService>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<UserSecretsStorageService>>();
-            return new UserSecretsStorageService(logger, _testUserSecretsId);
+            return new UserSecretsStorageService(logger, TestUserSecretsId);
         });
 
         return services.BuildServiceProvider();

--- a/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/ModelSelectionFlowTests.cs
+++ b/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/ModelSelectionFlowTests.cs
@@ -1,7 +1,8 @@
-using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using TenSecondTom.Features.Setup.Models;
 using TenSecondTom.Infrastructure.Configuration;
+using TenSecondTom.IntegrationTests.TestHelpers;
 using Xunit;
 
 namespace TenSecondTom.IntegrationTests.Integration.Features.Setup;
@@ -11,50 +12,15 @@ namespace TenSecondTom.IntegrationTests.Integration.Features.Setup;
 /// Verifies that model selection, storage, and retrieval work correctly.
 /// Each test uses a unique User Secrets ID to avoid interference with production configuration.
 /// </summary>
-public sealed class ModelSelectionFlowTests : IDisposable
+[Collection(UserSecretsCollection.Name)]
+public sealed class ModelSelectionFlowTests : UserSecretsTestFixture
 {
-    private readonly string _testUserSecretsId;
-
     public ModelSelectionFlowTests()
     {
-        // Use a unique ID for each test instance to avoid polluting production UserSecrets
-        _testUserSecretsId = $"TenSecondTom-Test-{Guid.NewGuid()}";
-    }
-
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Cleanup must not throw")]
-    public void Dispose()
-    {
-        // Clean up test UserSecrets directory
-        var userSecretsPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Microsoft",
-            "UserSecrets",
-            _testUserSecretsId);
-
-        if (Directory.Exists(userSecretsPath))
-        {
-            try
-            {
-                Directory.Delete(userSecretsPath, recursive: true);
-            }
-            catch (IOException)
-            {
-                // Retry after delay if directory is locked
-                Thread.Sleep(100);
-                try
-                {
-                    Directory.Delete(userSecretsPath, recursive: true);
-                }
-                catch
-                {
-                    // Ignore - cleanup script can handle orphaned directories
-                }
-            }
-            catch
-            {
-                // Ignore cleanup errors - don't fail tests because of cleanup
-            }
-        }
+        // Set up logger for the base fixture
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        Logger = loggerFactory.CreateLogger<UserSecretsTestFixture>();
     }
     [Fact]
     public async Task Setup_WithModelSelection_ShouldSaveModelToUserSecrets()
@@ -204,7 +170,7 @@ public sealed class ModelSelectionFlowTests : IDisposable
     private UserSecretsStorageService CreateStorageService()
     {
         var logger = new Microsoft.Extensions.Logging.Abstractions.NullLogger<UserSecretsStorageService>();
-        return new UserSecretsStorageService(logger, _testUserSecretsId);
+        return new UserSecretsStorageService(logger, TestUserSecretsId);
     }
 
     private static ConfigurationSettings CreateTestSettings(LlmProvider provider, string? modelId)

--- a/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/UserSecretsPersistenceTests.cs
+++ b/tests/TenSecondTom.IntegrationTests/Integration/Features/Setup/UserSecretsPersistenceTests.cs
@@ -16,55 +16,29 @@ namespace TenSecondTom.IntegrationTests.Integration.Features.Setup;
 /// Verifies configuration can be saved to and loaded from User Secrets.
 /// Each test uses a unique User Secrets ID to avoid interference.
 /// </summary>
-public sealed class UserSecretsPersistenceTests : IDisposable
+[Collection(UserSecretsCollection.Name)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "IAsyncLifetime pattern used instead of IDisposable")]
+public sealed class UserSecretsPersistenceTests : UserSecretsTestFixture
 {
     private readonly TemporaryTestDirectory _testDirectory;
-    private readonly string _testUserSecretsId;
 
     public UserSecretsPersistenceTests()
     {
         _testDirectory = new TemporaryTestDirectory();
-        // Use a unique ID for each test instance to avoid interference
-        _testUserSecretsId = $"TenSecondTom-Test-{Guid.NewGuid()}";
+
+        // Set up logger for the base fixture
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        Logger = loggerFactory.CreateLogger<UserSecretsTestFixture>();
     }
 
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Cleanup must not throw")]
-    public void Dispose()
+    public override async Task DisposeAsync()
     {
         // Clean up temporary test directory
         _testDirectory.Dispose();
-        
-        // Clean up test UserSecrets directory
-        var userSecretsPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Microsoft",
-            "UserSecrets",
-            _testUserSecretsId);
 
-        if (Directory.Exists(userSecretsPath))
-        {
-            try
-            {
-                Directory.Delete(userSecretsPath, recursive: true);
-            }
-            catch (IOException)
-            {
-                // Retry after delay if directory is locked
-                Thread.Sleep(100);
-                try
-                {
-                    Directory.Delete(userSecretsPath, recursive: true);
-                }
-                catch
-                {
-                    // Ignore - cleanup script can handle orphaned directories
-                }
-            }
-            catch
-            {
-                // Ignore cleanup errors - don't fail tests because of cleanup
-            }
-        }
+        // Call base cleanup for UserSecrets
+        await base.DisposeAsync();
     }
 
     [Fact]
@@ -331,11 +305,11 @@ public sealed class UserSecretsPersistenceTests : IDisposable
             .AddConsole()
             .SetMinimumLevel(LogLevel.Warning));
 
-        // Add real User Secrets storage service with test-specific ID
+        // Add real User Secrets storage service with test-specific ID from base fixture
         services.AddSingleton<IConfigurationStorageService>(sp =>
         {
             var logger = sp.GetRequiredService<ILogger<UserSecretsStorageService>>();
-            return new UserSecretsStorageService(logger, _testUserSecretsId);
+            return new UserSecretsStorageService(logger, TestUserSecretsId);
         });
 
         return services.BuildServiceProvider();

--- a/tests/TenSecondTom.IntegrationTests/TestHelpers/README.md
+++ b/tests/TenSecondTom.IntegrationTests/TestHelpers/README.md
@@ -1,0 +1,296 @@
+# Test Helpers - User Secrets Cleanup
+
+## Problem Statement
+
+Integration tests that use UserSecrets create temporary directories in `~/.microsoft/usersecrets/` with names like `TenSecondTom-Test-{guid}` or `tom-test-{guid}`. When tests fail, timeout, or are interrupted (Ctrl+C), the `IDisposable.Dispose()` or `IAsyncLifetime.DisposeAsync()` methods may not get called, leaving orphaned directories behind.
+
+Over time, hundreds or thousands of these orphaned directories can accumulate, consuming disk space and causing confusion during debugging.
+
+## Solution Architecture
+
+We implement a three-layer cleanup strategy:
+
+### 1. Test Fixture Base Class (`UserSecretsTestFixture`)
+
+**Purpose**: Provides robust, reusable cleanup logic for individual test classes.
+
+**Key Features**:
+- Implements `IAsyncLifetime` for xUnit lifecycle management
+- Generates unique test UserSecrets IDs with recognizable prefixes
+- Pre-test cleanup: Removes orphaned directories from previous failed runs
+- Post-test cleanup: Ensures cleanup even when tests fail
+- Retry logic: Handles file locks and race conditions (3 retries with 100ms delay)
+- Diagnostic logging: Helps troubleshoot cleanup issues
+
+**Usage Example**:
+```csharp
+[Collection(UserSecretsCollection.Name)]
+public sealed class MyIntegrationTests : UserSecretsTestFixture
+{
+    public MyIntegrationTests()
+    {
+        // Set up logger for diagnostic output
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        Logger = loggerFactory.CreateLogger<UserSecretsTestFixture>();
+    }
+
+    [Fact]
+    public async Task MyTest()
+    {
+        // Use TestUserSecretsId from base fixture
+        var storageService = new UserSecretsStorageService(logger, TestUserSecretsId);
+        // ... test code
+    }
+}
+```
+
+### 2. Collection Fixture (`UserSecretsCollectionFixture`)
+
+**Purpose**: Provides collection-wide cleanup before and after all tests in the collection run.
+
+**Key Features**:
+- Runs once per test collection (not per test class)
+- Pre-collection cleanup: Removes all orphaned test directories before any tests start
+- Post-collection cleanup: Final cleanup after all tests complete
+- Works across multiple test classes in the same collection
+
+**Usage Example**:
+```csharp
+// Apply collection attribute to all test classes that need cleanup
+[Collection(UserSecretsCollection.Name)]
+public sealed class MyTests : UserSecretsTestFixture
+{
+    // Tests here benefit from collection-wide cleanup
+}
+```
+
+### 3. Manual Cleanup Script (`.scripts/cleanup-test-secrets.sh`)
+
+**Purpose**: Allows developers to manually clean up orphaned directories.
+
+**Key Features**:
+- Cross-platform support (macOS, Linux, Windows via Git Bash)
+- Safe deletion with retry logic
+- Dry-run mode for preview
+- Verbose output for debugging
+- Finds and removes both naming patterns: `TenSecondTom-Test-*` and `tom-test-*`
+
+**Usage Examples**:
+```bash
+# Preview what would be deleted
+.scripts/cleanup-test-secrets.sh --dry-run
+
+# Delete orphaned directories
+.scripts/cleanup-test-secrets.sh
+
+# Verbose output for debugging
+.scripts/cleanup-test-secrets.sh --dry-run --verbose
+```
+
+## When to Use Each Approach
+
+| Scenario | Solution | Why |
+|----------|----------|-----|
+| Writing new integration tests | `UserSecretsTestFixture` base class | Automatic cleanup with minimal boilerplate |
+| Test collection needs pre/post cleanup | `UserSecretsCollectionFixture` | Ensures clean state for entire test collection |
+| Tests were interrupted (Ctrl+C) | Manual cleanup script | Removes accumulated orphaned directories |
+| CI/CD cleanup | Manual cleanup script in pipeline | Ensures clean build environment |
+| Debugging cleanup issues | Verbose logging + manual script | Diagnose why directories aren't being cleaned |
+
+## Implementation Details
+
+### Naming Convention
+
+All test UserSecrets directories use recognizable prefixes:
+- `TenSecondTom-Test-{guid}` - Standard pattern
+- `tom-test-{guid}` - Shorter pattern (used in some older tests)
+
+This makes it safe for cleanup scripts to identify and remove test directories without touching production UserSecrets.
+
+### Retry Logic
+
+Cleanup attempts use exponential backoff with retries:
+1. **Attempt 1**: Immediate cleanup
+2. **Attempt 2**: Wait 100ms, retry
+3. **Attempt 3**: Wait 100ms, retry
+4. **Failure**: Log error with instructions to run manual cleanup script
+
+### Error Handling
+
+Cleanup is designed to be non-fatal:
+- **Individual test cleanup failure**: Logs warning, continues with other tests
+- **Collection cleanup failure**: Logs error, provides manual cleanup instructions
+- **Script cleanup failure**: Reports failed count, suggests manual intervention
+
+## Best Practices
+
+### For Test Authors
+
+1. **Always inherit from `UserSecretsTestFixture`** for tests using UserSecrets
+2. **Add `[Collection(UserSecretsCollection.Name)]`** attribute to test classes
+3. **Use `TestUserSecretsId`** property instead of generating your own IDs
+4. **Implement `DisposeAsync`** if you have additional cleanup beyond UserSecrets
+5. **Call `base.DisposeAsync()`** at the end of your cleanup
+
+Example:
+```csharp
+[Collection(UserSecretsCollection.Name)]
+public sealed class MyTests : UserSecretsTestFixture
+{
+    private readonly TemporaryTestDirectory _tempDir;
+
+    public MyTests()
+    {
+        _tempDir = new TemporaryTestDirectory();
+
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        Logger = loggerFactory.CreateLogger<UserSecretsTestFixture>();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        // Clean up your resources first
+        _tempDir.Dispose();
+
+        // Then call base cleanup for UserSecrets
+        await base.DisposeAsync();
+    }
+}
+```
+
+### For CI/CD
+
+Add cleanup to your CI pipeline:
+```yaml
+# Before tests
+- name: Clean up orphaned test secrets
+  run: .scripts/cleanup-test-secrets.sh
+
+# Run tests
+- name: Run integration tests
+  run: dotnet test
+
+# After tests (even if tests fail)
+- name: Final cleanup
+  if: always()
+  run: .scripts/cleanup-test-secrets.sh
+```
+
+### For Developers
+
+Run cleanup periodically:
+```bash
+# Check how many orphaned directories exist
+ls ~/.microsoft/usersecrets/ | grep -c "TenSecondTom-Test"
+
+# Clean them up
+.scripts/cleanup-test-secrets.sh
+```
+
+## Troubleshooting
+
+### Problem: Tests still leaving orphaned directories
+
+**Diagnosis**:
+1. Check if tests are inheriting from `UserSecretsTestFixture`
+2. Verify tests have `[Collection(UserSecretsCollection.Name)]` attribute
+3. Enable verbose logging to see cleanup attempts
+
+**Solution**:
+- Update tests to use the fixture pattern
+- Run manual cleanup script to remove existing orphans
+
+### Problem: "Permission denied" errors during cleanup
+
+**Diagnosis**:
+- Directory may be locked by another process
+- File permissions may be restrictive
+
+**Solution**:
+1. Close any running test processes
+2. Wait a few seconds for locks to release
+3. Re-run cleanup script (retry logic will handle transient locks)
+4. If persistent, manually delete with elevated permissions
+
+### Problem: Cleanup script not finding directories
+
+**Diagnosis**:
+- UserSecrets location may differ by OS
+- Directory naming pattern may have changed
+
+**Solution**:
+1. Verify UserSecrets location: `~/.microsoft/usersecrets/` (macOS/Linux) or `%APPDATA%\Microsoft\UserSecrets\` (Windows)
+2. Check for directories matching patterns: `TenSecondTom-Test-*` or `tom-test-*`
+3. Update script if naming convention changed
+
+## Migration Guide
+
+### Migrating Existing Tests
+
+If you have existing tests using the old cleanup pattern:
+
+**Before**:
+```csharp
+public sealed class MyTests : IDisposable
+{
+    private readonly string _testSecretsId;
+
+    public MyTests()
+    {
+        _testSecretsId = $"TenSecondTom-Test-{Guid.NewGuid()}";
+    }
+
+    public void Dispose()
+    {
+        var path = Path.Combine(..., _testSecretsId);
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Cleanup fails silently - directories left behind!
+        }
+    }
+}
+```
+
+**After**:
+```csharp
+[Collection(UserSecretsCollection.Name)]
+public sealed class MyTests : UserSecretsTestFixture
+{
+    public MyTests()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        Logger = loggerFactory.CreateLogger<UserSecretsTestFixture>();
+    }
+
+    // No need to implement DisposeAsync if only cleaning up UserSecrets
+    // Base class handles it automatically with retry logic
+}
+```
+
+**Benefits**:
+- Automatic retry on cleanup failures
+- Pre-test cleanup of orphaned directories
+- Collection-wide cleanup
+- Diagnostic logging
+- Less boilerplate code
+
+## References
+
+- **xUnit IAsyncLifetime**: https://xunit.net/docs/shared-context#async-lifetime
+- **xUnit Collection Fixtures**: https://xunit.net/docs/shared-context#collection-fixture
+- **UserSecrets Documentation**: https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets
+
+---
+
+**Last Updated**: 2025-10-21
+**Related Files**:
+- `/Users/chris/Repos/ten-second-tom/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsTestFixture.cs`
+- `/Users/chris/Repos/ten-second-tom/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsCollectionFixture.cs`
+- `/Users/chris/Repos/ten-second-tom/.scripts/cleanup-test-secrets.sh`

--- a/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsCollectionFixture.cs
+++ b/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsCollectionFixture.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.Logging;
+
+namespace TenSecondTom.IntegrationTests.TestHelpers;
+
+/// <summary>
+/// Collection fixture for UserSecrets integration tests.
+/// Provides test-wide cleanup of orphaned directories before and after test execution.
+/// </summary>
+/// <remarks>
+/// This fixture runs once per test collection, performing:
+/// - Pre-test cleanup of orphaned directories from previous failed/interrupted runs
+/// - Post-test cleanup of any remaining test directories
+///
+/// Use with xUnit's [Collection] attribute on test classes:
+/// <code>
+/// [Collection(UserSecretsCollection.Name)]
+/// public class MyTests
+/// {
+///     // Tests here will benefit from collection-wide cleanup
+/// }
+/// </code>
+/// </remarks>
+public sealed class UserSecretsCollectionFixture : IAsyncLifetime
+{
+    private readonly ILogger<UserSecretsCollectionFixture> _logger;
+
+    public UserSecretsCollectionFixture()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Information));
+        _logger = loggerFactory.CreateLogger<UserSecretsCollectionFixture>();
+    }
+
+    /// <summary>
+    /// Runs before any tests in the collection execute.
+    /// Performs cleanup of orphaned test directories from previous runs.
+    /// </summary>
+    public Task InitializeAsync()
+    {
+        _logger.LogInformation("UserSecrets collection fixture initializing - performing pre-test cleanup");
+        CleanupAllTestDirectories("Pre-test cleanup");
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Runs after all tests in the collection complete.
+    /// Performs final cleanup of any remaining test directories.
+    /// </summary>
+    public Task DisposeAsync()
+    {
+        _logger.LogInformation("UserSecrets collection fixture disposing - performing post-test cleanup");
+        CleanupAllTestDirectories("Post-test cleanup");
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Cleans up all test UserSecrets directories.
+    /// </summary>
+    private void CleanupAllTestDirectories(string context)
+    {
+        var userSecretsRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "Microsoft",
+            "UserSecrets");
+
+        if (!Directory.Exists(userSecretsRoot))
+        {
+            _logger.LogDebug("{Context}: UserSecrets root directory does not exist", context);
+            return;
+        }
+
+        try
+        {
+            // Find all test directories (both naming patterns)
+            var testDirectories = Directory.GetDirectories(userSecretsRoot)
+                .Where(dir =>
+                {
+                    var name = Path.GetFileName(dir);
+                    return name.StartsWith("TenSecondTom-Test-", StringComparison.OrdinalIgnoreCase) ||
+                           name.StartsWith("tom-test-", StringComparison.OrdinalIgnoreCase);
+                })
+                .ToList();
+
+            if (testDirectories.Count == 0)
+            {
+                _logger.LogInformation("{Context}: No test directories found to clean up", context);
+                return;
+            }
+
+            _logger.LogInformation(
+                "{Context}: Found {Count} test directories to clean up",
+                context, testDirectories.Count);
+
+            int cleanedCount = 0;
+            int failedCount = 0;
+
+            foreach (var directory in testDirectories)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                    cleanedCount++;
+                    _logger.LogDebug("Deleted: {Directory}", Path.GetFileName(directory));
+                }
+                catch (Exception ex)
+                {
+                    failedCount++;
+                    _logger.LogWarning(
+                        "Failed to delete {Directory}: {Error}",
+                        Path.GetFileName(directory), ex.Message);
+                }
+            }
+
+            _logger.LogInformation(
+                "{Context} complete: Removed {Cleaned} directories, {Failed} failed",
+                context, cleanedCount, failedCount);
+
+            if (failedCount > 0)
+            {
+                _logger.LogWarning(
+                    "Some directories could not be removed. " +
+                    "Run '.scripts/cleanup-test-secrets.sh' for manual cleanup.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("{Context} failed: {Error}", context, ex.Message);
+        }
+    }
+}
+
+/// <summary>
+/// xUnit collection definition for UserSecrets tests.
+/// </summary>
+[CollectionDefinition(Name)]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1711:Identifiers should not have incorrect suffix", Justification = "xUnit collection naming convention requires 'Collection' suffix")]
+public sealed class UserSecretsCollection : ICollectionFixture<UserSecretsCollectionFixture>
+{
+    public const string Name = "UserSecrets Collection";
+    // This class is never instantiated. It exists only to define the collection.
+}

--- a/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsTestFixture.cs
+++ b/tests/TenSecondTom.IntegrationTests/TestHelpers/UserSecretsTestFixture.cs
@@ -1,0 +1,228 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+
+namespace TenSecondTom.IntegrationTests.TestHelpers;
+
+/// <summary>
+/// Base class for tests that use UserSecrets with robust cleanup.
+/// Implements IAsyncLifetime for xUnit lifecycle management and provides
+/// retry logic for cleanup to handle file locks and race conditions.
+/// </summary>
+/// <remarks>
+/// This fixture addresses the common issue of orphaned UserSecrets directories
+/// when tests fail, timeout, or are interrupted. It provides:
+/// - Automatic cleanup with retry logic for file locks
+/// - Pre-test cleanup to handle orphaned directories from previous runs
+/// - Post-test cleanup even when tests fail
+/// - Diagnostic logging for troubleshooting cleanup issues
+/// </remarks>
+public abstract class UserSecretsTestFixture : IAsyncLifetime
+{
+    private const int MaxCleanupRetries = 3;
+    private const int CleanupRetryDelayMs = 100;
+
+    protected string TestUserSecretsId { get; private set; } = string.Empty;
+    protected ILogger? Logger { get; set; }
+
+    /// <summary>
+    /// Gets the path to the UserSecrets directory for this test instance.
+    /// </summary>
+    protected string UserSecretsPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Microsoft",
+        "UserSecrets",
+        TestUserSecretsId);
+
+    /// <summary>
+    /// Initializes the fixture before tests run.
+    /// Creates a unique UserSecrets ID and performs pre-test cleanup.
+    /// </summary>
+    public virtual Task InitializeAsync()
+    {
+        // Generate unique test ID with recognizable prefix for cleanup scripts
+        TestUserSecretsId = $"TenSecondTom-Test-{Guid.NewGuid()}";
+
+        // Pre-test cleanup: Remove any orphaned directories from previous failed runs
+        // This is defensive - in case previous test runs were interrupted
+        CleanupOrphanedTestDirectories();
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Cleans up the fixture after tests complete.
+    /// Ensures UserSecrets directory is removed even if tests fail.
+    /// </summary>
+    public virtual Task DisposeAsync()
+    {
+        // Always attempt cleanup, even if tests failed
+        CleanupUserSecretsDirectory();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Cleans up the UserSecrets directory for this test instance with retry logic.
+    /// </summary>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Cleanup must not throw")]
+    protected void CleanupUserSecretsDirectory()
+    {
+        if (string.IsNullOrEmpty(TestUserSecretsId))
+        {
+            return;
+        }
+
+        var directoryPath = UserSecretsPath;
+
+        if (!Directory.Exists(directoryPath))
+        {
+            Logger?.LogDebug("UserSecrets directory does not exist: {Path}", directoryPath);
+            return;
+        }
+
+        // Attempt cleanup with retry logic
+        for (int attempt = 1; attempt <= MaxCleanupRetries; attempt++)
+        {
+            try
+            {
+                Directory.Delete(directoryPath, recursive: true);
+                Logger?.LogDebug("Successfully cleaned up UserSecrets directory: {Path}", directoryPath);
+                return;
+            }
+            catch (IOException ex) when (attempt < MaxCleanupRetries)
+            {
+                // Directory may be locked - retry after delay
+                Logger?.LogWarning(
+                    "Cleanup attempt {Attempt}/{Max} failed for {Path}: {Error}. Retrying after {Delay}ms...",
+                    attempt, MaxCleanupRetries, directoryPath, ex.Message, CleanupRetryDelayMs);
+
+                Thread.Sleep(CleanupRetryDelayMs);
+            }
+            catch (UnauthorizedAccessException) when (attempt < MaxCleanupRetries)
+            {
+                // Permissions issue - retry after delay
+                Logger?.LogWarning(
+                    "Cleanup attempt {Attempt}/{Max} failed (access denied) for {Path}. Retrying after {Delay}ms...",
+                    attempt, MaxCleanupRetries, directoryPath, CleanupRetryDelayMs);
+
+                Thread.Sleep(CleanupRetryDelayMs);
+            }
+            catch (Exception cleanupException)
+            {
+                // Final attempt or unexpected error - log and continue
+                Logger?.LogError(
+                    "Failed to cleanup UserSecrets directory after {Attempt} attempt(s): {Path}. Error: {Error}. " +
+                    "Run '.scripts/cleanup-test-secrets.sh' to manually cleanup orphaned directories.",
+                    attempt, directoryPath, cleanupException.Message);
+                return;
+            }
+        }
+
+        // All retries exhausted
+        Logger?.LogError(
+            "Failed to cleanup UserSecrets directory after {Max} attempts: {Path}. " +
+            "Directory may be left behind. Run '.scripts/cleanup-test-secrets.sh' to cleanup.",
+            MaxCleanupRetries, directoryPath);
+    }
+
+    /// <summary>
+    /// Cleans up orphaned test directories from previous test runs.
+    /// This is a defensive measure to handle cases where previous tests were interrupted.
+    /// </summary>
+    /// <remarks>
+    /// Only removes directories that match the test naming pattern (TenSecondTom-Test-* or tom-test-*).
+    /// This runs before each test fixture initialization to ensure a clean state.
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Pre-cleanup is best-effort")]
+    protected void CleanupOrphanedTestDirectories()
+    {
+        var userSecretsRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "Microsoft",
+            "UserSecrets");
+
+        if (!Directory.Exists(userSecretsRoot))
+        {
+            return;
+        }
+
+        try
+        {
+            // Find all orphaned test directories
+            var testDirectories = Directory.GetDirectories(userSecretsRoot)
+                .Where(dir =>
+                {
+                    var name = Path.GetFileName(dir);
+                    return name.StartsWith("TenSecondTom-Test-", StringComparison.OrdinalIgnoreCase) ||
+                           name.StartsWith("tom-test-", StringComparison.OrdinalIgnoreCase);
+                })
+                .ToList();
+
+            if (testDirectories.Count == 0)
+            {
+                return;
+            }
+
+            Logger?.LogInformation(
+                "Found {Count} orphaned test directories from previous runs. Cleaning up...",
+                testDirectories.Count);
+
+            int cleanedCount = 0;
+            int failedCount = 0;
+
+            foreach (var directory in testDirectories)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                    cleanedCount++;
+                }
+                catch (Exception ex)
+                {
+                    // Log but don't fail - cleanup is best-effort
+                    Logger?.LogWarning(
+                        "Failed to cleanup orphaned directory {Path}: {Error}",
+                        directory, ex.Message);
+                    failedCount++;
+                }
+            }
+
+            Logger?.LogInformation(
+                "Orphaned directory cleanup complete. Removed: {Cleaned}, Failed: {Failed}",
+                cleanedCount, failedCount);
+
+            if (failedCount > 0)
+            {
+                Logger?.LogWarning(
+                    "Some orphaned directories could not be removed. " +
+                    "Run '.scripts/cleanup-test-secrets.sh' for manual cleanup.");
+            }
+        }
+        catch (Exception ex)
+        {
+            // Pre-cleanup failure should not fail tests
+            Logger?.LogWarning(
+                "Error during orphaned directory cleanup: {Error}. Continuing with tests.",
+                ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Helper method to verify that UserSecrets directory was created.
+    /// Useful for assertions in tests.
+    /// </summary>
+    protected bool UserSecretsDirectoryExists() => Directory.Exists(UserSecretsPath);
+
+    /// <summary>
+    /// Helper method to get files in the UserSecrets directory.
+    /// Useful for test assertions.
+    /// </summary>
+    protected string[] GetUserSecretsFiles()
+    {
+        if (!Directory.Exists(UserSecretsPath))
+        {
+            return [];
+        }
+
+        return Directory.GetFiles(UserSecretsPath, "*.*", SearchOption.AllDirectories);
+    }
+}

--- a/tests/TenSecondTom.Tests/Unit/Features/Setup/Handlers/ConfigCommandHandlerTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Features/Setup/Handlers/ConfigCommandHandlerTests.cs
@@ -24,6 +24,7 @@ public sealed class ConfigCommandHandlerTests
     private readonly Mock<ISetupWizardUI> _mockSetupWizard;
     private readonly Mock<IApiKeyValidator> _mockOpenAIValidator;
     private readonly Mock<IApiKeyValidator> _mockAnthropicValidator;
+    private readonly Mock<IAppSettingsStorageService> _mockAppSettingsStorage;
     private readonly Mock<ILogger<ConfigCommandHandler>> _mockLogger;
     private readonly ConfigCommandHandler _handler;
 
@@ -34,6 +35,7 @@ public sealed class ConfigCommandHandlerTests
         _mockSetupWizard = new Mock<ISetupWizardUI>();
         _mockOpenAIValidator = new Mock<IApiKeyValidator>();
         _mockAnthropicValidator = new Mock<IApiKeyValidator>();
+        _mockAppSettingsStorage = new Mock<IAppSettingsStorageService>();
         _mockLogger = new Mock<ILogger<ConfigCommandHandler>>();
 
         _mockOpenAIValidator.Setup(v => v.Provider).Returns(LlmProvider.OpenAI);
@@ -50,7 +52,8 @@ public sealed class ConfigCommandHandlerTests
             _mockStorageService.Object,
             _mockConfiguration.Object,
             _mockSetupWizard.Object,
-            validators, 
+            validators,
+            _mockAppSettingsStorage.Object,
             _mockLogger.Object);
     }
 
@@ -65,6 +68,7 @@ public sealed class ConfigCommandHandlerTests
             _mockConfiguration.Object,
             _mockSetupWizard.Object,
             new[] { _mockOpenAIValidator.Object },
+            _mockAppSettingsStorage.Object,
             _mockLogger.Object);
 
         act.Should().Throw<ArgumentNullException>()
@@ -80,6 +84,7 @@ public sealed class ConfigCommandHandlerTests
             _mockConfiguration.Object,
             null!,
             new[] { _mockOpenAIValidator.Object },
+            _mockAppSettingsStorage.Object,
             _mockLogger.Object);
 
         act.Should().Throw<ArgumentNullException>()
@@ -95,10 +100,27 @@ public sealed class ConfigCommandHandlerTests
             _mockConfiguration.Object,
             _mockSetupWizard.Object,
             null!,
+            _mockAppSettingsStorage.Object,
             _mockLogger.Object);
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("apiKeyValidators");
+    }
+
+    [Fact]
+    public void Constructor_WithNullAppSettingsStorage_ShouldThrowArgumentNullException()
+    {
+        // Arrange, Act & Assert
+        var act = () => new ConfigCommandHandler(
+            _mockStorageService.Object,
+            _mockConfiguration.Object,
+            _mockSetupWizard.Object,
+            new[] { _mockOpenAIValidator.Object },
+            null!,
+            _mockLogger.Object);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("appSettingsStorage");
     }
 
     [Fact]
@@ -110,6 +132,7 @@ public sealed class ConfigCommandHandlerTests
             _mockConfiguration.Object,
             _mockSetupWizard.Object,
             new[] { _mockOpenAIValidator.Object },
+            _mockAppSettingsStorage.Object,
             null!);
 
         act.Should().Throw<ArgumentNullException>()

--- a/tests/TenSecondTom.Tests/Unit/Features/Setup/Handlers/SpectreConsoleSetupWizardTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Features/Setup/Handlers/SpectreConsoleSetupWizardTests.cs
@@ -183,4 +183,31 @@ public sealed class SpectreConsoleSetupWizardTests
             // The fix ensures .EscapeMarkup() is called on the entire formatted string
         }
     }
+
+    #region Audio Configuration Prompt Tests
+
+    [Fact]
+    public void AudioPromptMethods_ShouldExistWithCorrectSignatures()
+    {
+        // Arrange & Act - Verify method exists and has correct signature
+        var inputVolumeMethod = typeof(SpectreConsoleSetupWizard).GetMethod("PromptForInputVolumeAsync");
+        var booleanMethod = typeof(SpectreConsoleSetupWizard).GetMethod("PromptForBooleanAsync");
+        var intMethod = typeof(SpectreConsoleSetupWizard).GetMethod("PromptForIntAsync");
+        var sttMethod = typeof(SpectreConsoleSetupWizard).GetMethod("PromptForSttPreferenceAsync");
+
+        // Assert
+        inputVolumeMethod.Should().NotBeNull("PromptForInputVolumeAsync method should exist");
+        inputVolumeMethod!.ReturnType.Should().Be<Task<double?>>();
+
+        booleanMethod.Should().NotBeNull("PromptForBooleanAsync method should exist");
+        booleanMethod!.ReturnType.Should().Be<Task<bool?>>();
+
+        intMethod.Should().NotBeNull("PromptForIntAsync method should exist");
+        intMethod!.ReturnType.Should().Be<Task<int?>>();
+
+        sttMethod.Should().NotBeNull("PromptForSttPreferenceAsync method should exist");
+        sttMethod!.ReturnType.Should().Be<Task<string?>>();
+    }
+
+    #endregion
 }

--- a/tests/TenSecondTom.Tests/Unit/Infrastructure/Configuration/AppSettingsStorageServiceTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Infrastructure/Configuration/AppSettingsStorageServiceTests.cs
@@ -1,0 +1,160 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TenSecondTom.Infrastructure.Configuration;
+using Xunit;
+
+namespace TenSecondTom.Tests.Unit.Infrastructure.Configuration;
+
+/// <summary>
+/// Unit tests for AppSettingsStorageService
+/// Tests appsettings.json updates and atomic operations
+/// </summary>
+public sealed class AppSettingsStorageServiceTests : IDisposable
+{
+    private readonly string _testDirectory;
+    private readonly string _testAppSettingsPath;
+    private readonly Mock<ILogger<AppSettingsStorageService>> _mockLogger;
+
+    public AppSettingsStorageServiceTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"tom-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testDirectory);
+        _testAppSettingsPath = Path.Combine(_testDirectory, "appsettings.json");
+        _mockLogger = new Mock<ILogger<AppSettingsStorageService>>();
+    }
+
+    [Fact]
+    public async Task SaveAudioConfigurationAsync_WithNewFile_ShouldCreateFile()
+    {
+        // Arrange
+        var service = new AppSettingsStorageService(_mockLogger.Object, _testAppSettingsPath);
+        var audioConfig = new AudioConfiguration
+        {
+            PreferredStt = "local",
+            KeepFiles = false,
+            Recorder = new RecorderConfiguration { InputVolume = 0.8 }
+        };
+
+        // Act
+        var result = await service.SaveAudioConfigurationAsync(audioConfig, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        File.Exists(_testAppSettingsPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAudioConfigurationAsync_ShouldPreserveOtherSections()
+    {
+        // Arrange
+        var initialJson = """
+        {
+          "TenSecondTom": {
+            "MemoryDirectory": "/test/path"
+          }
+        }
+        """;
+        await File.WriteAllTextAsync(_testAppSettingsPath, initialJson);
+
+        var service = new AppSettingsStorageService(_mockLogger.Object, _testAppSettingsPath);
+        var audioConfig = new AudioConfiguration
+        {
+            PreferredStt = "auto",
+            Recorder = new RecorderConfiguration { InputVolume = 1.0 }
+        };
+
+        // Act
+        var result = await service.SaveAudioConfigurationAsync(audioConfig, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var content = await File.ReadAllTextAsync(_testAppSettingsPath);
+        content.Should().Contain("MemoryDirectory");
+        content.Should().Contain("/test/path");
+    }
+
+    [Fact]
+    public async Task LoadAudioConfigurationAsync_WithExistingConfig_ShouldReturnConfiguration()
+    {
+        // Arrange
+        var json = """
+        {
+          "TenSecondTom": {
+            "Audio": {
+              "PreferredStt": "openai",
+              "KeepFiles": true,
+              "Recorder": {
+                "InputVolume": 1.2,
+                "EnableNoiseReduction": false
+              }
+            }
+          }
+        }
+        """;
+        await File.WriteAllTextAsync(_testAppSettingsPath, json);
+
+        var service = new AppSettingsStorageService(_mockLogger.Object, _testAppSettingsPath);
+
+        // Act
+        var result = await service.LoadAudioConfigurationAsync(CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.PreferredStt.Should().Be("openai");
+        result.Value.KeepFiles.Should().BeTrue();
+        result.Value.Recorder.InputVolume.Should().Be(1.2);
+    }
+
+    [Fact]
+    public async Task LoadAudioConfigurationAsync_WithMissingFile_ShouldReturnDefaults()
+    {
+        // Arrange
+        var service = new AppSettingsStorageService(_mockLogger.Object, _testAppSettingsPath);
+
+        // Act
+        var result = await service.LoadAudioConfigurationAsync(CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.PreferredStt.Should().Be("auto"); // Default value
+    }
+
+    [Fact]
+    public async Task SaveAudioConfigurationAsync_WithConcurrentWrites_ShouldNotCorruptFile()
+    {
+        // Arrange
+        var service = new AppSettingsStorageService(_mockLogger.Object, _testAppSettingsPath);
+        var config1 = new AudioConfiguration { PreferredStt = "local" };
+        var config2 = new AudioConfiguration { PreferredStt = "openai" };
+
+        // Act
+        var task1 = service.SaveAudioConfigurationAsync(config1, CancellationToken.None);
+        var task2 = service.SaveAudioConfigurationAsync(config2, CancellationToken.None);
+        var results = await Task.WhenAll(task1, task2);
+
+        // Assert
+        results.Should().AllSatisfy(r => r.IsSuccess.Should().BeTrue());
+
+        // File should be valid JSON (not corrupted)
+        var loadResult = await service.LoadAudioConfigurationAsync(CancellationToken.None);
+        loadResult.IsSuccess.Should().BeTrue();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDirectory, recursive: true);
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added AppSettingsStorageService for managing audio configuration in appsettings.json.
- Enhanced ConfigCommandHandler to support interactive audio configuration setup.
- Introduced new methods in ISetupWizardUI for prompting user input related to audio settings.
- Updated DependencyInjection to register the new AppSettingsStorageService.
- Added integration tests for audio configuration handling and unit tests for AppSettingsStorageService.

---

This pull request introduces an interactive audio configuration wizard to the CLI, allowing users to configure audio recording and preprocessing settings step-by-step. It also adds a robust utility script for cleaning up orphaned test secrets directories, and makes supporting changes to dependency injection and UI interfaces.

**Interactive Audio Configuration:**

- Adds a new interactive wizard for configuring audio settings (`tom config --set audio`). Users can adjust input volume, noise reduction, silence removal, preferred STT engine, and timeouts through guided prompts. The configuration is saved to `appsettings.json` and integrates with the existing setup workflow. [[1]](diffhunk://#diff-6b2f146bbfe453186493f5ae3087e2e8b0c4ff6e51516b4a4f25f9901d2b113cR219-R224) [[2]](diffhunk://#diff-6b2f146bbfe453186493f5ae3087e2e8b0c4ff6e51516b4a4f25f9901d2b113cR542-R752)
- Extends the `ISetupWizardUI` interface with new prompt methods for audio configuration steps, including input volume, booleans, integer ranges, and STT engine selection.
- Registers the new `IAppSettingsStorageService` for managing audio configuration storage.
- Updates the `ConfigCommandHandler` constructor and logic to support audio configuration and app settings storage.

**Developer Tooling & Documentation:**

- Adds `.scripts/cleanup-test-secrets.sh`, a cross-platform script for cleaning up orphaned UserSecrets directories left by failed or interrupted tests. Features dry-run, verbose mode, color output, and safe deletion with retries.
- Documents the new script and its usage in `.scripts/README.md`.

**Other Minor Changes:**

- Removes the "Retry Mechanism" feature from the main `README.md` feature list for clarity.
- Minor formatting cleanup in the `README.md`.