### PR TITLE
feat: Introduce SetupCommandFactory to streamline setup entry

### DIFF
--- a/src/Features/Setup/DependencyInjection.cs
+++ b/src/Features/Setup/DependencyInjection.cs
@@ -22,6 +22,9 @@ public static class SetupFeatureExtensions
         services.AddTransient<SetupCommandHandler>();
         services.AddTransient<ConfigCommandHandler>();
         
+        // Setup command factory (centralizes logic for creating SetupCommand with existing config)
+        services.AddTransient<SetupCommandFactory>();
+        
         // Application bootstrapper (coordinates startup/setup logic)
         services.AddTransient<ApplicationBootstrapper>();
         

--- a/src/Features/Setup/Handlers/SetupCommandHandler.cs
+++ b/src/Features/Setup/Handlers/SetupCommandHandler.cs
@@ -180,6 +180,7 @@ public sealed class SetupCommandHandler
                     RetentionDays = retentionDays ?? -1, // -1 means unlimited (never delete)
                     EnableTelemetry = false
                 },
+                Audio = command.ExistingConfiguration?.Audio ?? new AudioConfigurationDisplay(),
                 CreatedAt = command.ExistingConfiguration?.CreatedAt ?? DateTime.UtcNow,
                 LastModifiedAt = isReconfiguration ? DateTime.UtcNow : null,
                 ConfigurationVersion = "1.0"

--- a/src/Features/Setup/Services/ApplicationBootstrapper.cs
+++ b/src/Features/Setup/Services/ApplicationBootstrapper.cs
@@ -23,6 +23,7 @@ public sealed class ApplicationBootstrapper
     private readonly IServiceProvider _serviceProvider;
     private readonly IConfiguration _configuration;
     private readonly ILogger<ApplicationBootstrapper> _logger;
+    private readonly SetupCommandFactory _setupCommandFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ApplicationBootstrapper"/> class.
@@ -30,11 +31,13 @@ public sealed class ApplicationBootstrapper
     public ApplicationBootstrapper(
         IServiceProvider serviceProvider,
         IConfiguration configuration,
-        ILogger<ApplicationBootstrapper> logger)
+        ILogger<ApplicationBootstrapper> logger,
+        SetupCommandFactory setupCommandFactory)
     {
         _serviceProvider = serviceProvider;
         _configuration = configuration;
         _logger = logger;
+        _setupCommandFactory = setupCommandFactory ?? throw new ArgumentNullException(nameof(setupCommandFactory));
     }
 
     /// <summary>
@@ -242,14 +245,11 @@ public sealed class ApplicationBootstrapper
     /// </summary>
     private async Task<Result<Features.Setup.Models.ConfigurationSettings>> RunSetupAsync(bool force, CancellationToken cancellationToken)
     {
+        // Use factory to create SetupCommand with existing config loaded (centralized logic)
+        var setupCommand = await _setupCommandFactory.CreateAsync(force, nonInteractive: false, cancellationToken)
+            .ConfigureAwait(false);
+        
         var setupHandler = _serviceProvider.GetRequiredService<SetupCommandHandler>();
-        var setupCommand = new SetupCommand
-        {
-            Force = force,
-            NonInteractive = false,
-            ExistingConfiguration = null
-        };
-
         return await setupHandler.Handle(setupCommand, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Features/Setup/Services/SetupCommandFactory.cs
+++ b/src/Features/Setup/Services/SetupCommandFactory.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Logging;
+using TenSecondTom.Features.Setup.Commands;
+using TenSecondTom.Features.Setup.Models;
+using TenSecondTom.Infrastructure.Configuration;
+
+namespace TenSecondTom.Features.Setup.Services;
+
+/// <summary>
+/// Factory for creating SetupCommand instances with proper existing configuration loading.
+/// Centralizes the logic to prevent duplication and bugs from inconsistent implementations.
+/// </summary>
+public sealed class SetupCommandFactory
+{
+    private readonly IConfigurationStorageService _storageService;
+    private readonly ILogger<SetupCommandFactory> _logger;
+
+    public SetupCommandFactory(
+        IConfigurationStorageService storageService,
+        ILogger<SetupCommandFactory> logger)
+    {
+        _storageService = storageService ?? throw new ArgumentNullException(nameof(storageService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Creates a SetupCommand with existing configuration loaded if available.
+    /// This ensures all callers (CLI, Bootstrapper, etc.) consistently preserve existing settings.
+    /// </summary>
+    /// <param name="force">Force setup to run even if configuration exists.</param>
+    /// <param name="nonInteractive">Run setup in non-interactive mode.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A SetupCommand with ExistingConfiguration properly loaded.</returns>
+    public async Task<SetupCommand> CreateAsync(
+        bool force = false,
+        bool nonInteractive = false,
+        CancellationToken cancellationToken = default)
+    {
+        var existingConfig = await LoadExistingConfigurationAsync(cancellationToken);
+        
+        return new SetupCommand
+        {
+            Force = force,
+            NonInteractive = nonInteractive,
+            ExistingConfiguration = existingConfig
+        };
+    }
+
+    /// <summary>
+    /// Loads existing configuration if it exists and contains real (non-default) values.
+    /// </summary>
+    private async Task<ConfigurationSettings?> LoadExistingConfigurationAsync(CancellationToken cancellationToken)
+    {
+        var loadResult = await _storageService.LoadAsync(cancellationToken).ConfigureAwait(false);
+        
+        if (!loadResult.IsSuccess || loadResult.Value == null)
+        {
+            _logger.LogDebug("No existing configuration found");
+            return null;
+        }
+
+        var config = loadResult.Value;
+        
+        // Check if it's a real config (not just defaults from a missing file)
+        // We check for ANY non-default values to preserve (SSH, LLM, or Audio config)
+        bool hasRealConfig = !string.IsNullOrEmpty(config.Ssh.KeyPath) ||
+                            !string.IsNullOrEmpty(config.Ssh.AgentSocketPath) ||
+                            !string.IsNullOrEmpty(config.Llm.ApiKey) ||
+                            !string.IsNullOrEmpty(config.Audio.SttApiKey) ||
+                            config.Audio.SttProvider != "whisper-cpp"; // Non-default STT provider
+
+        if (hasRealConfig)
+        {
+            _logger.LogDebug("Loaded existing configuration for reconfiguration (valid: {IsValid})", 
+                config.IsValid());
+            return config;
+        }
+
+        _logger.LogDebug("Config file contains only defaults, treating as first-time setup");
+        return null;
+    }
+}
+

--- a/src/Features/Setup/Services/SpectreConsoleSetupWizard.cs
+++ b/src/Features/Setup/Services/SpectreConsoleSetupWizard.cs
@@ -167,7 +167,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
 
         if (!string.IsNullOrEmpty(currentApiKey))
         {
-            prompt.DefaultValue(MaskApiKey(currentApiKey));
+            prompt.DefaultValue(currentApiKey);
         }
 
         var apiKey = _console.Prompt(prompt);
@@ -420,7 +420,7 @@ public sealed class SpectreConsoleSetupWizard : ISetupWizardUI
 
         if (!string.IsNullOrEmpty(currentApiKey))
         {
-            prompt.DefaultValue(MaskApiKey(currentApiKey));
+            prompt.DefaultValue(currentApiKey);
         }
 
         var apiKey = _console.Prompt(prompt);

--- a/src/Infrastructure/Cli/CommandRegistry.cs
+++ b/src/Infrastructure/Cli/CommandRegistry.cs
@@ -539,15 +539,11 @@ public static class CommandRegistry
             bool nonInteractive = parseResult.GetValue(nonInteractiveOption);
             bool jsonOutput = parseResult.GetValue(jsonOutputOption);
 
-            var handler = serviceProvider.GetRequiredService<SetupCommandHandler>();
-            
-            var command = new SetupCommand
-            {
-                Force = force,
-                NonInteractive = nonInteractive,
-                ExistingConfiguration = null
-            };
+            // Use factory to create SetupCommand with existing config loaded (centralized logic)
+            var factory = serviceProvider.GetRequiredService<SetupCommandFactory>();
+            var command = await factory.CreateAsync(force, nonInteractive, CancellationToken.None).ConfigureAwait(false);
 
+            var handler = serviceProvider.GetRequiredService<SetupCommandHandler>();
             var result = await handler.Handle(command, CancellationToken.None).ConfigureAwait(false);
 
             if (result.IsSuccess)

--- a/src/Infrastructure/Cli/ConfigCommandBuilder.cs
+++ b/src/Infrastructure/Cli/ConfigCommandBuilder.cs
@@ -320,7 +320,7 @@ internal static class ConfigCommandBuilder
         table.AddRow("  Model", modelDisplay);
 
         string apiKeyDisplay = showSecrets
-            ? config.Llm.ApiKey ?? "[dim]Not set[/]"
+            ? (config.Llm.ApiKey?.EscapeMarkup() ?? "[dim]Not set[/]")
             : MaskApiKey(config.Llm.ApiKey);
         table.AddRow("  API Key", apiKeyDisplay);
 

--- a/src/Infrastructure/Configuration/ConfigurationStorageService.cs
+++ b/src/Infrastructure/Configuration/ConfigurationStorageService.cs
@@ -22,7 +22,9 @@ public sealed class ConfigurationStorageService : IConfigurationStorageService, 
     {
         WriteIndented = true,
         // Default PascalCase naming matches .NET configuration system
-        PropertyNameCaseInsensitive = true
+        PropertyNameCaseInsensitive = true,
+        // Serialize enums as strings (e.g., "OpenAI" instead of 0)
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
     };
 
     public ConfigurationStorageService(

--- a/tests/TenSecondTom.Tests/Unit/Features/Setup/Handlers/SetupCommandHandlerTests.cs
+++ b/tests/TenSecondTom.Tests/Unit/Features/Setup/Handlers/SetupCommandHandlerTests.cs
@@ -631,6 +631,97 @@ public sealed class SetupCommandHandlerTests
         savedConfig!.Optional.EnableTelemetry.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task Handle_WithReconfiguration_PreservesAudioConfiguration()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var existingAudioConfig = new AudioConfigurationDisplay
+        {
+            SttProvider = "openai",
+            SttApiKey = "sk-audio123",
+            SttFallbackEnabled = true,
+            SttFallbackProvider = "whisper-cpp",
+            SttFallbackApiKey = "fallback-key",
+            KeepFiles = false,
+            Recorder = new RecorderConfigurationDisplay
+            {
+                InputVolume = 1.5,
+                EnableNoiseReduction = false,
+                EnableFrequencyFilters = true
+            },
+            Preprocessing = new PreprocessingConfigurationDisplay
+            {
+                RemoveSilence = false,
+                SilenceThresholdDb = -40,
+                MinimumSilenceDurationMs = 1000
+            }
+        };
+
+        var existingConfig = new ConfigurationSettings
+        {
+            Ssh = new SshConfiguration
+            {
+                KeyPath = "/Users/test/.ssh/id_ed25519",
+                KeySource = SshKeySource.FileSystem,
+                AgentSocketPath = null
+            },
+            Llm = new LlmConfiguration
+            {
+                Provider = LlmProvider.OpenAI,
+                ApiKey = "sk-test123456789012345678901234567890123456789012",
+                Model = null
+            },
+            RootDirectory = "/Users/test/.memory/ten-second-tom",
+            Storage = new StorageConfiguration
+            {
+                CreateIfMissing = true
+            },
+            Optional = new OptionalConfiguration
+            {
+                LogLevel = Microsoft.Extensions.Logging.LogLevel.Information,
+                RetentionDays = 30,
+                EnableTelemetry = false
+            },
+            Audio = existingAudioConfig,
+            CreatedAt = DateTime.UtcNow.AddDays(-30),
+            LastModifiedAt = null,
+            ConfigurationVersion = "1.0"
+        };
+
+        var command = new SetupCommand
+        {
+            Force = true,
+            NonInteractive = false,
+            ExistingConfiguration = existingConfig
+        };
+
+        ConfigurationSettings? savedConfig = null;
+
+        SetupHappyPathMocksExceptStorage();
+
+        _mockStorageService
+            .Setup(x => x.SaveAsync(It.IsAny<ConfigurationSettings>(), It.IsAny<CancellationToken>()))
+            .Callback<ConfigurationSettings, CancellationToken>((config, ct) => savedConfig = config)
+            .ReturnsAsync(Result<string>.Success("/path"));
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        savedConfig.Should().NotBeNull();
+        savedConfig!.Audio.Should().NotBeNull();
+        savedConfig.Audio.SttProvider.Should().Be("openai");
+        savedConfig.Audio.SttApiKey.Should().Be("sk-audio123");
+        savedConfig.Audio.SttFallbackEnabled.Should().BeTrue();
+        savedConfig.Audio.SttFallbackProvider.Should().Be("whisper-cpp");
+        savedConfig.Audio.KeepFiles.Should().BeFalse();
+        savedConfig.Audio.Recorder.InputVolume.Should().Be(1.5);
+        savedConfig.Audio.Recorder.EnableNoiseReduction.Should().BeFalse();
+        savedConfig.Audio.Preprocessing.RemoveSilence.Should().BeFalse();
+        savedConfig.Audio.Preprocessing.SilenceThresholdDb.Should().Be(-40);
+    }
+
     // NOTE: This test is commented out because Setup.Handler no longer uses IConfiguration directly.
     // Environment variable configuration is now handled at the Program.cs level and tested in integration tests.
     // See SetupWithTemplatesIntegrationTests for end-to-end environment variable testing.


### PR DESCRIPTION
- fix: resolves critical configuration bug when setup is run manually, can wipe existing config.

---

This pull request introduces a centralized factory for creating `SetupCommand` instances, ensuring consistent loading and preservation of existing configuration settings across the application. It refactors setup logic in both the CLI and application bootstrapper to use this factory, improves configuration handling, and adds related tests. Additionally, it enhances configuration serialization and fixes some display issues.

### Setup command creation and configuration handling

* Added `SetupCommandFactory` (`src/Features/Setup/Services/SetupCommandFactory.cs`) to centralize logic for loading existing configuration and creating `SetupCommand` instances, preventing duplication and inconsistencies. Both CLI and bootstrapper now use this factory. [[1]](diffhunk://#diff-56d1e0277130aaff30f4150d24f93334776572e33020915a5320be416ef84abbR1-R82) [[2]](diffhunk://#diff-71776311979eefc154280af5363977471728795fc8152851c402b3445f7013bcR25-R27) [[3]](diffhunk://#diff-abc8e26c69a7793e6d08edf2a29699e544dfb5c2b942565b8dbbc78dbf4aaba9R26-R40) [[4]](diffhunk://#diff-abc8e26c69a7793e6d08edf2a29699e544dfb5c2b942565b8dbbc78dbf4aaba9L245-R252) [[5]](diffhunk://#diff-8b6232913558c98e3d8a170eb013ca570464dc3cf300c3424f04eacf0899af23L542-R546)
* Refactored `SetupCommandHandler` to always preserve the audio configuration from the existing config during reconfiguration, ensuring user settings are retained.

### Configuration serialization and display

* Modified configuration serialization to store enums as strings instead of integers, improving readability and compatibility.
* Fixed API key display in configuration tables to properly escape markup and avoid formatting issues.
* Updated setup wizard to show the actual API key as the default value in prompts, rather than a masked version, for a better user experience. [[1]](diffhunk://#diff-c88f068bdc5f7fb497d920d61ed66d4b25a7c32001820d4d5efde8b769ecab40L170-R170) [[2]](diffhunk://#diff-c88f068bdc5f7fb497d920d61ed66d4b25a7c32001820d4d5efde8b769ecab40L423-R423)

### Testing

* Added a unit test to verify that audio configuration is preserved when handling setup with an existing configuration, increasing reliability of reconfiguration logic.