### PR TITLE
chore: Add TenSecondTom to TrimmerRootAssembly for improved trimming …

### DIFF
--- a/src/TenSecondTom.csproj
+++ b/src/TenSecondTom.csproj
@@ -28,6 +28,7 @@
     <TrimmerRootAssembly Include="Anthropic.SDK" />
     <TrimmerRootAssembly Include="MediatR" />
     <TrimmerRootAssembly Include="FluentValidation" />
+    <TrimmerRootAssembly Include="TenSecondTom" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- ensures all custom types, especially those needed for reflection, are included in the published binary

This pull request makes a minor update to the project file by adding the assembly `TenSecondTom` as a root for trimming. This ensures that the trimming process preserves all necessary code from this assembly during publish or deployment.