### PR TITLE
Sync package versions from release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,33 +153,3 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Version:** $VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "**Package:** [ten-second-tom](https://www.npmjs.com/package/ten-second-tom)" >> "$GITHUB_STEP_SUMMARY"
-
-  sync-version:
-    name: Sync version to main
-    runs-on: ubuntu-latest
-    needs: [validate-tag, publish]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Update versioned files
-        env:
-          VERSION: ${{ needs.validate-tag.outputs.version }}
-        run: node scripts/set-release-version.mjs "$VERSION"
-
-      - name: Commit version bump
-        env:
-          VERSION: ${{ needs.validate-tag.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/cli/package.json packages/core/package.json packages/cli/src/constants.ts
-          git diff --cached --quiet && exit 0
-          git commit -m "chore(release): sync package version to $VERSION [skip ci]"
-          git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,15 +141,33 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check npm package version
+        id: npm-version
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: |
+          if npm view "ten-second-tom@$VERSION" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "ten-second-tom@$VERSION is already published"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish package
+        if: steps.npm-version.outputs.exists != 'true'
         working-directory: packages/cli
         run: npx npm@latest publish --provenance --access public
 
       - name: Publish summary
         env:
           VERSION: ${{ needs.validate-tag.outputs.version }}
+          VERSION_EXISTS: ${{ steps.npm-version.outputs.exists }}
         run: |
-          echo "## Published to npmjs.org" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$VERSION_EXISTS" = "true" ]; then
+            echo "## Package already published on npmjs.org" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Published to npmjs.org" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Version:** $VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo "**Package:** [ten-second-tom](https://www.npmjs.com/package/ten-second-tom)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -1,0 +1,69 @@
+name: Sync package versions on release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+
+concurrency:
+  group: sync-package-versions
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync package versions from release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: extract
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG_NAME" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Update versioned files
+        env:
+          VERSION: ${{ steps.extract.outputs.version }}
+        run: node scripts/set-release-version.mjs "$VERSION"
+
+      - name: Commit and push if changed
+        env:
+          VERSION: ${{ steps.extract.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add packages/cli/package.json packages/core/package.json packages/cli/src/constants.ts
+
+          if git diff --cached --quiet; then
+            echo "No version changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore(release): sync package version to $VERSION [skip ci]"
+          git push

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -1,5 +1,5 @@
 version: 3
-config_version: 5
+config_version: 6
 embedding:
   provider: ollama
   model: bge-m3
@@ -25,20 +25,22 @@ agent:
     type: anthropic
     model: claude-sonnet-4-6
   tasks:
-    full-intelligence:
+    skill-survey:
+      provider:
+        type: anthropic
+      schedule:
+        enabled: false
+    vault-evolve:
       provider:
         type: anthropic
       schedule:
         runIn:
           - idle
           - sleep
-    skill-survey:
-      provider:
-        type: anthropic
-      schedule:
-        enabled: false
 context:
   digest_tier: 5000
+  session_start_digest_enabled: false
+  cortex_enabled: true
   prompt_search: true
   prompt_max_spores: 3
 backup: {}


### PR DESCRIPTION
## Summary
- move package version write-back into a dedicated tag-triggered workflow
- use PUSH_TOKEN when configured, falling back to GITHUB_TOKEN
- keep npm publishing separate from version sync so already-published versions can still write back cleanly

## Verification
- make check