### PR TITLE
Derive CLI version from package metadata

### DIFF
--- a/.github/workflows/sync-package-versions.yml
+++ b/.github/workflows/sync-package-versions.yml
@@ -58,7 +58,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add packages/cli/package.json packages/core/package.json packages/cli/src/constants.ts
+          git add packages/cli/package.json packages/core/package.json
 
           if git diff --cached --quiet; then
             echo "No version changes to commit"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { APP_VERSION } from './constants.js';
+import { APP_VERSION } from './version.js';
 
 const args = process.argv.slice(2);
 const KNOWN_COMMANDS = ['record', 'note', 'search', 'analyze', 'setup', 'list', 'reindex'];

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -4,5 +4,3 @@ export const EXIT_HINT_TEXT = 'Press Enter or q to exit.';
 
 /** Left one-quarter block — used as a sentiment-colored border in list views. */
 export const BORDER_CHAR = '\u258E';
-
-export const APP_VERSION = "2.0.1";

--- a/packages/cli/src/screens/HomeScreen.tsx
+++ b/packages/cli/src/screens/HomeScreen.tsx
@@ -2,9 +2,9 @@ import React, { useCallback } from 'react';
 import { Box, Text } from 'ink';
 import type { AppConfig } from 'ten-second-tom-core';
 import { Prompt } from '../components/Prompt.js';
-import { APP_VERSION } from '../constants.js';
 import { COMMANDS, findCommand } from '../commands/registry.js';
 import type { AppContext } from '../commands/registry.js';
+import { APP_VERSION } from '../version.js';
 
 const DIVIDER = '───────────────────────────────────────';
 

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+
+const FALLBACK_VERSION = '0.0.0-dev';
+const PACKAGE_JSON_URL = new URL('../package.json', import.meta.url);
+
+type PackageMetadata = {
+  version?: unknown;
+};
+
+function readPackageVersion(): string {
+  try {
+    const metadata = JSON.parse(readFileSync(PACKAGE_JSON_URL, 'utf8')) as PackageMetadata;
+    return typeof metadata.version === 'string' && metadata.version.length > 0
+      ? metadata.version
+      : FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}
+
+export const APP_VERSION = readPackageVersion();

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -37,19 +37,5 @@ function updatePackageVersion(relativePath) {
   writeJson(relativePath, pkg);
 }
 
-function updateCliVersionConstant() {
-  const relativePath = 'packages/cli/src/constants.ts';
-  const absolutePath = path.join(repoRoot, relativePath);
-  const current = fs.readFileSync(absolutePath, 'utf8');
-  const next = current.replace(
-    /export const APP_VERSION = '.*';/,
-    `export const APP_VERSION = ${JSON.stringify(version)};`,
-  );
-
-  if (current === next) return;
-  fs.writeFileSync(absolutePath, next, 'utf8');
-}
-
 updatePackageVersion('packages/cli/package.json');
 updatePackageVersion('packages/core/package.json');
-updateCliVersionConstant();


### PR DESCRIPTION
## Summary
- stop rewriting source constants during release version sync
- read the CLI version from package.json at runtime for --version and the TUI header
- update the release write-back workflow to commit only package manifests

## Verification
- pnpm --filter ten-second-tom build && node packages/cli/dist/cli.js --version
- make check