### PR TITLE
Isolate tom-dev configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,18 @@ check: lint format-check test ## Run all checks (lint, format, tests)
 # ─── Dev Convenience ─────────────────────────────────────────────────────────
 
 
-link-dev: build ## Link 'tom-dev' binary globally for local testing
+link-dev: build ## Install 'tom-dev' wrapper globally for local testing
 	@mkdir -p $(HOME)/.local/bin
-	@ln -sf $(PWD)/packages/cli/dist/cli.js $(HOME)/.local/bin/tom-dev
+	@rm -f $(HOME)/.local/bin/tom-dev
+	@printf '%s\n' \
+		'#!/usr/bin/env sh' \
+		'export TOM_HOME="$${TOM_HOME:-$$HOME/.tom-dev}"' \
+		'exec node "$(CURDIR)/packages/cli/dist/cli.js" "$$@"' \
+		> $(HOME)/.local/bin/tom-dev
 	@chmod +x $(HOME)/.local/bin/tom-dev
 	@echo ""
-	@echo "  'tom-dev' is now linked to your local build."
+	@echo "  'tom-dev' now runs your local build."
+	@echo "  Dev config/data directory: $(HOME)/.tom-dev"
 	@echo "  Run 'tom-dev setup' to get started."
 	@echo "  Run 'make unlink-dev' when done."
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Run `tom setup` to configure your LLM provider and embedding strategy. The setup
 
 For cloud analysis, you'll need an [Anthropic API key](https://console.anthropic.com/). For local analysis, [install Ollama](https://ollama.ai) and pull a model (e.g., `ollama pull qwen2.5:7b`).
 
+Set `TOM_HOME` to use a different configuration and data directory. The `make link-dev`
+workflow installs a `tom-dev` wrapper that defaults to `~/.tom-dev`, keeping development
+configuration separate from the globally installed `tom` package.
+
 ## Development
 
 ### Install Dependencies

--- a/packages/core/src/config/__tests__/config-manager.test.ts
+++ b/packages/core/src/config/__tests__/config-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,6 +8,7 @@ import type { AppConfig } from '../../types/config.js';
 let tempDir: string;
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   if (tempDir) {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -109,6 +110,18 @@ describe('ConfigManager', () => {
     const manager = new ConfigManager(homePath);
 
     expect(manager.homePath).toBe(homePath);
+  });
+
+  it('uses TOM_HOME as the default home directory when set', () => {
+    const dir = createTempDir();
+    const homePath = join(dir, '.tom-dev');
+    vi.stubEnv('TOM_HOME', homePath);
+
+    const manager = new ConfigManager();
+
+    expect(manager.homePath).toBe(homePath);
+    expect(manager.audioPath).toBe(join(homePath, 'audio'));
+    expect(manager.modelsPath).toBe(join(homePath, 'models'));
   });
 
   it('returns audio directory path', () => {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { AppConfigSchema, type AppConfig } from '../types/config.js';
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE } from '../constants.js';
 
+const TOM_HOME_ENV = 'TOM_HOME';
+
 function chmodBestEffort(path: string, mode: number): void {
   try {
     chmodSync(path, mode);
@@ -23,7 +25,9 @@ export class ConfigManager {
 
   constructor(homePath?: string) {
     this.homePath =
-      homePath ?? join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.tom');
+      homePath ??
+      process.env[TOM_HOME_ENV] ??
+      join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.tom');
     this.audioPath = join(this.homePath, 'audio');
     this.modelsPath = join(this.homePath, 'models');
     this.configFilePath = join(this.homePath, 'config.json');


### PR DESCRIPTION
## Summary
- add TOM_HOME support to ConfigManager for alternate app homes
- change make link-dev from a symlink to a wrapper that defaults TOM_HOME to ~/.tom-dev
- document the TOM_HOME override and tom-dev isolation behavior

## Verification
- pnpm vitest run packages/core/src/config/__tests__/config-manager.test.ts
- make link-dev && tom-dev --version
- tom --version
- make check